### PR TITLE
Remove object spread on initial data

### DIFF
--- a/packages/react-wildcat-prefetch/src/index.js
+++ b/packages/react-wildcat-prefetch/src/index.js
@@ -63,9 +63,7 @@ function prefetch(action, key) {
                     var newState = {};
 
                     if (initialDataTarget && initialDataTarget[key]) {
-                        initialData = {
-                            ...initialDataTarget[key]
-                        };
+                        initialData = initialDataTarget[key];
 
                         // Delete stored object
                         delete initialDataTarget[key];


### PR DESCRIPTION
Incoming initial data can be a string / object / array, so let's remove this spread.

Test Plan:

- `make install`

Expected:

- All tests should pass