### PR TITLE
Suppress white flash between server / client render

### DIFF
--- a/example/src/routes/PrefetchExample/routes.js
+++ b/example/src/routes/PrefetchExample/routes.js
@@ -4,8 +4,7 @@ export const path = "/prefetch-example";
 // Lazy loaded components
 export async function getComponent(location, cb) {
     try {
-        const Module = await System.import("./PrefetchExample.js", module.id);
-        return cb(null, Module);
+        return cb(null, await System.import("./PrefetchExample.js", module.id));
     } catch (e) {
         return cb(e);
     }

--- a/packages/react-wildcat-handoff/src/client.js
+++ b/packages/react-wildcat-handoff/src/client.js
@@ -1,11 +1,14 @@
 require("isomorphic-fetch");
 var ReactDOM = require("react-dom");
+var Router = require("react-router");
 
 var history = require("history");
 var clientRouter = require("./utils/clientRouter.js");
 var getDomainRoutes = require("./utils/getDomainRoutes.js");
+var match = Router.match;
 
 var createHistory = history.createHistory;
+var createLocation = history.createLocation;
 var __REACT_ROOT_ID__ = "__REACT_ROOT_ID__";
 
 function completeRender(cfg, routes) {
@@ -14,18 +17,40 @@ function completeRender(cfg, routes) {
     }
 
     var component = clientRouter(cfg);
-    var reactRootElementID = window[__REACT_ROOT_ID__];
-    var reactRootElement = document.getElementById(reactRootElementID);
+    console.time("render");
 
-    ReactDOM.render(component, reactRootElement);
+    match(cfg, (error, redirectLocation, renderProps) => {
+        // return Promise.all(
+        //     renderProps.routes
+        //         .filter(route => Object.keys(route).some(key => (/^get/).test(key)))
+        //         .map(route => {
+        //             return Promise.all(
+        //                 Object.keys(route)
+        //                     .filter(key => (/^get/).test(key))
+        //                     .map(key => {
+        //                         console.log(key, route[key]);
+        //                         return new Promise(resolve => route[key](renderProps.location, resolve))
+        //                     })
+        //             );
+        //         })
+        // )
+        // .then(() => {
+            var reactRootElementID = window[__REACT_ROOT_ID__];
+            var reactRootElement = document.getElementById(reactRootElementID);
 
-    // Flag react as available
-    // This is a helpful hook for running tests
-    reactRootElement.setAttribute("data-react-available", true);
+            ReactDOM.render(component, reactRootElement);
+
+            // Flag react as available
+            // This is a helpful hook for running tests
+            reactRootElement.setAttribute("data-react-available", true);
+            console.timeEnd("render");
+        // });
+    });
 }
 
 function render(cfg) {
     cfg.history = createHistory();
+    cfg.location = createLocation(location.pathname);
 
     if (!cfg.routes && cfg.domains) {
         return getDomainRoutes(cfg.domains, location, function (err, routes) {

--- a/packages/react-wildcat-handoff/src/client.js
+++ b/packages/react-wildcat-handoff/src/client.js
@@ -18,7 +18,7 @@ function completeRender(cfg, routes) {
 
     var component = clientRouter(cfg);
 
-    match(cfg, (error, redirectLocation, renderProps) => {
+    match(cfg, () => {
         var reactRootElementID = window[__REACT_ROOT_ID__];
         var reactRootElement = document.getElementById(reactRootElementID);
 

--- a/packages/react-wildcat-handoff/src/client.js
+++ b/packages/react-wildcat-handoff/src/client.js
@@ -17,34 +17,16 @@ function completeRender(cfg, routes) {
     }
 
     var component = clientRouter(cfg);
-    console.time("render");
 
     match(cfg, (error, redirectLocation, renderProps) => {
-        // return Promise.all(
-        //     renderProps.routes
-        //         .filter(route => Object.keys(route).some(key => (/^get/).test(key)))
-        //         .map(route => {
-        //             return Promise.all(
-        //                 Object.keys(route)
-        //                     .filter(key => (/^get/).test(key))
-        //                     .map(key => {
-        //                         console.log(key, route[key]);
-        //                         return new Promise(resolve => route[key](renderProps.location, resolve))
-        //                     })
-        //             );
-        //         })
-        // )
-        // .then(() => {
-            var reactRootElementID = window[__REACT_ROOT_ID__];
-            var reactRootElement = document.getElementById(reactRootElementID);
+        var reactRootElementID = window[__REACT_ROOT_ID__];
+        var reactRootElement = document.getElementById(reactRootElementID);
 
-            ReactDOM.render(component, reactRootElement);
+        ReactDOM.render(component, reactRootElement);
 
-            // Flag react as available
-            // This is a helpful hook for running tests
-            reactRootElement.setAttribute("data-react-available", true);
-            console.timeEnd("render");
-        // });
+        // Flag react as available
+        // This is a helpful hook for running tests
+        reactRootElement.setAttribute("data-react-available", true);
     });
 }
 

--- a/packages/react-wildcat-handoff/src/utils/renderContext.js
+++ b/packages/react-wildcat-handoff/src/utils/renderContext.js
@@ -3,7 +3,7 @@
 const React = require("react");
 const ReactDOM = require("react-dom/server");
 const Helmet = require("react-helmet");
-const router = require("react-router");
+const Router = require("react-router");
 const defaultTemplate = require("./defaultTemplate.js");
 
 const radium = require("react-wildcat-radium");
@@ -11,8 +11,8 @@ const matchMediaMock = require("match-media-mock").create();
 
 const getClientSize = require("./clientSize.js").getClientSize;
 
-const RoutingContext = router.RoutingContext;
-const match = router.match;
+const RoutingContext = Router.RoutingContext;
+const match = Router.match;
 
 radium.setMatchMedia(matchMediaMock);
 


### PR DESCRIPTION
Use the `match` helper to do some client-side route-matching, which supresses the delay between server and client rendering.

Test Plan:

- `make install`

Expected:

- All tests should pass