### PR TITLE
Convert arrow functions to es5

### DIFF
--- a/packages/react-wildcat-handoff/.npmignore
+++ b/packages/react-wildcat-handoff/.npmignore
@@ -1,1 +1,2 @@
 .DS_Store
+dist

--- a/packages/react-wildcat-handoff/src/utils/clientRender.js
+++ b/packages/react-wildcat-handoff/src/utils/clientRender.js
@@ -10,8 +10,8 @@ var __REACT_ROOT_ID__ = "__REACT_ROOT_ID__";
 module.exports = function clientRender(cfg) {
     var component = clientRouter(cfg);
 
-    return new Promise((resolve) => {
-        match(cfg, () => {
+    return new Promise(function (resolve) {
+        match(cfg, function () {
             var reactRootElementID = window[__REACT_ROOT_ID__];
             var reactRootElement = document.getElementById(reactRootElementID);
 


### PR DESCRIPTION
This file gets rendered as-is on the client, but not all of our target browsers support arrow functions.