### PR TITLE
react-wildcat-ensure

### DIFF
--- a/example/src/routes/ErrorExample/routes.js
+++ b/example/src/routes/ErrorExample/routes.js
@@ -1,12 +1,11 @@
+import ensure from "react-wildcat-ensure";
+
 // React router route
 export const path = "/error-example";
 
 // Lazy loaded components
-export async function getComponent(location, cb) {
-    try {
-        const Module = await System.import("./ErrorExample.js", module.id);
-        return cb(null, Module);
-    } catch (e) {
-        return cb(e);
-    }
+export function getComponent(location, cb) {
+    return ensure("./ErrorExample.js", module, (err, module) => {
+        return cb(err, module);
+    });
 }

--- a/example/src/routes/FlexboxExample/routes.js
+++ b/example/src/routes/FlexboxExample/routes.js
@@ -1,12 +1,11 @@
+import ensure from "react-wildcat-ensure";
+
 // React router route
 export const path = "/flexbox-example";
 
 // Lazy loaded components
-export async function getComponent(location, cb) {
-    try {
-        const Module = await System.import("./FlexboxExample.js", module.id);
-        return cb(null, Module);
-    } catch (e) {
-        return cb(e);
-    }
+export function getComponent(location, cb) {
+    return ensure("./FlexboxExample.js", module, (err, module) => {
+        return cb(err, module);
+    });
 }

--- a/example/src/routes/HelmetExample/routes.js
+++ b/example/src/routes/HelmetExample/routes.js
@@ -1,12 +1,11 @@
+import ensure from "react-wildcat-ensure";
+
 // React router route
 export const path = "/helmet-example";
 
 // Lazy loaded components
-export async function getComponent(location, cb) {
-    try {
-        const Module = await System.import("./HelmetExample.js", module.id);
-        return cb(null, Module);
-    } catch (e) {
-        return cb(e);
-    }
+export function getComponent(location, cb) {
+    return ensure("./HelmetExample.js", module, (err, module) => {
+        return cb(err, module);
+    });
 }

--- a/example/src/routes/IndexExample/routes.js
+++ b/example/src/routes/IndexExample/routes.js
@@ -1,9 +1,8 @@
+import ensure from "react-wildcat-ensure";
+
 // Lazy loaded components
-export async function getComponent(location, cb) {
-    try {
-        const Module = await System.import("./IndexExample.js", module.id);
-        return cb(null, Module);
-    } catch (e) {
-        return cb(e);
-    }
+export function getComponent(location, cb) {
+    return ensure("./IndexExample.js", module, (err, module) => {
+        return cb(err, module);
+    });
 }

--- a/example/src/routes/PrefetchExample/routes.js
+++ b/example/src/routes/PrefetchExample/routes.js
@@ -1,11 +1,11 @@
+import ensure from "react-wildcat-ensure";
+
 // React router route
 export const path = "/prefetch-example";
 
 // Lazy loaded components
-export async function getComponent(location, cb) {
-    try {
-        return cb(null, await System.import("./PrefetchExample.js", module.id));
-    } catch (e) {
-        return cb(e);
-    }
+export function getComponent(location, cb) {
+    ensure(["./PrefetchExample"], module, function (err, [module]) {
+        return cb(err, module);
+    });
 }

--- a/packages/react-wildcat-ensure/.npmignore
+++ b/packages/react-wildcat-ensure/.npmignore
@@ -1,0 +1,6 @@
+.DS_Store
+dist/test
+jspm_packages
+reports
+src
+*.config.js

--- a/packages/react-wildcat-ensure/README.md
+++ b/packages/react-wildcat-ensure/README.md
@@ -25,7 +25,7 @@ npm:
 npm install react-wildcat-ensure
 ```
 
-## Example
+## Usage
 
 Importing a single module:
 

--- a/packages/react-wildcat-ensure/README.md
+++ b/packages/react-wildcat-ensure/README.md
@@ -1,0 +1,77 @@
+<img src="http://static.nfl.com/static/content/public/static/img/logos/nfl-engineering-light.svg" width="300" />
+
+# react-wildcat-ensure
+
+[![npm package](https://img.shields.io/npm/v/react-wildcat-ensure.svg?style=flat-square)](https://www.npmjs.org/package/react-wildcat-ensure)
+
+A wrapper for [`System.import`](https://github.com/systemjs/systemjs) that behaves like Webpack's [`require.ensure`](https://webpack.github.io/docs/code-splitting.html#require-ensure):
+
+- initial import calls are asynchronous
+- subsequent import calls returns a synchronous cached import response
+
+Designed for compatibility with React Router's [asynchronous route loading](https://github.com/rackt/react-router/blob/master/docs/guides/advanced/DynamicRouting.md).
+
+## Installation
+
+jspm:
+
+```bash
+jspm install react-wildcat-ensure
+```
+
+npm:
+
+```bash
+npm install react-wildcat-ensure
+```
+
+## Example
+
+Importing a single module:
+
+```js
+import ensure from "react-wildcat-ensure";
+
+// Lazy loaded component
+export function getComponent(location, cb) {
+    ensure("./AsyncComponent.js", module, (err, module) => {
+        return cb(err, module);
+    });
+}
+```
+
+Importing a key/value hash of modules:
+
+```js
+import ensure from "react-wildcat-ensure";
+
+// Lazy loaded index route
+export function getIndexRoute(location, cb) {
+    ensure({
+      header: "./AsyncHeader.js",
+      component: "./AsyncComponent.js"
+    }, module, (err, modules) => {
+        return cb(err, modules);
+    });
+}
+```
+
+Importing an array of modules:
+
+```js
+import ensure from "react-wildcat-ensure";
+
+// Lazy loaded child routes
+export function getChildRoutes(location, cb) {
+    ensure([
+      "./AsyncChildRouteOne.js",
+      "./AsyncChildRouteTwo.js"
+    ], module, (err, modules) => {
+        return cb(err, modules);
+    });
+}
+```
+
+# License
+
+MIT

--- a/packages/react-wildcat-ensure/package.json
+++ b/packages/react-wildcat-ensure/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "react-wildcat-ensure",
+  "version": "1.0.0-beta2",
+  "description": "An asynchronous System.import helper.",
+  "main": "dist/index.js",
+  "devDependencies": {
+    "babel": "^5.8.29",
+    "rimraf": "^2.4.3"
+  },
+  "scripts": {
+    "build": "npm run clean && npm run compile",
+    "clean": "rimraf dist",
+    "compile": "babel src --out-dir dist",
+    "prepublish": "env NODE_ENV=production npm run build",
+    "pretest": "npm run prepublish"
+  },
+  "author": "engineers@nfl.com",
+  "license": "MIT"
+}

--- a/packages/react-wildcat-ensure/src/index.js
+++ b/packages/react-wildcat-ensure/src/index.js
@@ -1,0 +1,49 @@
+const __moduleCache = {};
+
+function ensure(importPaths, {id}, cb) {
+    if (!__moduleCache[id]) {
+        // Handle a single import
+        if (typeof importPaths === "string") {
+            return System.import(importPaths, id)
+                .then(module => {
+                    __moduleCache[id] = module;
+                    return cb(null, __moduleCache[id]);
+                })
+                .catch(e => cb(e));
+        }
+
+        // Handle an array of imports
+        if (Array.isArray(importPaths)) {
+            return Promise.all(
+                importPaths
+                    .map(importPath => System.import(importPath, id))
+            )
+                .then(modules => {
+                    __moduleCache[id] = modules;
+                    return cb(null, __moduleCache[id]);
+                })
+                .catch(e => cb(e));
+        }
+
+        const moduleHashCache = {};
+
+        // Handle a key/value hash of imports
+        return Promise.all(
+            Object.keys(importPaths)
+                .map(moduleName => System.import(importPaths[moduleName], id))
+        )
+            .then(modules => {
+                Object.keys(importPaths)
+                    .forEach((moduleName, idx) => moduleHashCache[moduleName] = modules[idx]);
+
+                __moduleCache[id] = moduleHashCache;
+                return cb(null, __moduleCache[id]);
+            })
+            .catch(e => cb(e));
+    }
+
+    return cb(null, __moduleCache[id]);
+}
+
+export {__moduleCache};
+export default ensure;

--- a/packages/react-wildcat-ensure/src/test/browser/ensureSpec.js
+++ b/packages/react-wildcat-ensure/src/test/browser/ensureSpec.js
@@ -1,0 +1,196 @@
+import ensure, {__moduleCache} from "../../index.js"; // eslint-disable-line import/default, import/named
+import {path, getComponent} from "./fixtures/routes.js";
+import {getComponents as getComponentsUsingArray} from "./fixtures/routesArray.js";
+import {getComponents as getComponentsUsingHash} from "./fixtures/routesHash.js";
+
+import {getComponent as getMissingComponent} from "./fixtures/routesMissing.js";
+import {getComponents as getMissingComponentsUsingHash} from "./fixtures/routesMissingHash.js";
+import {getComponents as getMissingComponentsUsingArray} from "./fixtures/routesMissingArray.js";
+
+/* eslint-disable max-nested-callbacks, react/no-multi-comp */
+describe("react-wildcat-ensure", () => {
+    it("exists", () => {
+        expect(ensure)
+            .to.be.a("function")
+            .that.has.property("name")
+            .that.equals("ensure");
+
+        expect(__moduleCache)
+            .to.be.an("object");
+
+        expect(path)
+            .to.be.a("string");
+
+        expect(getComponent)
+            .to.be.a("function")
+            .that.has.property("name")
+            .that.equals("getComponent");
+
+        expect(getComponentsUsingArray)
+            .to.be.a("function")
+            .that.has.property("name")
+            .that.equals("getComponents");
+
+        expect(getComponentsUsingHash)
+            .to.be.a("function")
+            .that.has.property("name")
+            .that.equals("getComponents");
+    });
+
+    context("import", () => {
+        context("single import", () => {
+            it("asynchronously imports a module", (done) => {
+                getComponent(location, (err, module) => {
+                    expect(err)
+                        .to.not.exist;
+
+                    expect(module)
+                        .to.exist;
+
+                    done();
+                });
+            });
+
+            it("returns a cached module on subsequent requests", (done) => {
+                getComponent(location, (err, module) => {
+                    expect(err)
+                        .to.not.exist;
+
+                    expect(module)
+                        .to.exist;
+
+                    done();
+                });
+            });
+        });
+
+        context("multiple imports", () => {
+            context("as key/value hash", () => {
+                it("asynchronously imports multiple modules", (done) => {
+                    getComponentsUsingHash(location, (err, modules) => {
+                        expect(err)
+                            .to.not.exist;
+
+                        expect(modules)
+                            .to.exist;
+
+                        expect(modules)
+                            .to.be.an("object")
+                            .that.has.keys([
+                                "one",
+                                "two"
+                            ]);
+
+                        done();
+                    });
+                });
+
+                it("returns cached modules on subsequent requests", (done) => {
+                    getComponentsUsingHash(location, (err, modules) => {
+                        expect(err)
+                            .to.not.exist;
+
+                        expect(modules)
+                            .to.exist;
+
+                        expect(modules)
+                            .to.be.an("object")
+                            .that.has.keys([
+                                "one",
+                                "two"
+                            ]);
+
+                        done();
+                    });
+                });
+            });
+
+            context("as array", () => {
+                it("asynchronously imports multiple modules", (done) => {
+                    getComponentsUsingArray(location, (err, modules) => {
+                        expect(err)
+                            .to.not.exist;
+
+                        expect(modules)
+                            .to.exist;
+
+                        expect(modules)
+                            .to.be.an("array")
+                            .that.has.length.of(2);
+
+                        done();
+                    });
+                });
+
+                it("returns cached modules on subsequent requests", (done) => {
+                    getComponentsUsingArray(location, (err, modules) => {
+                        expect(err)
+                            .to.not.exist;
+
+                        expect(modules)
+                            .to.exist;
+
+                        expect(modules)
+                            .to.be.an("array")
+                            .that.has.length.of(2);
+
+                        done();
+                    });
+                });
+            });
+        });
+
+        context("sad path", () => {
+            it("handles error on single module", (done) => {
+                getMissingComponent(location, (err, module) => {
+                    expect(err)
+                        .to.exist;
+
+                    expect(module)
+                        .to.not.exist;
+
+                    expect(err)
+                        .to.be.an.instanceof(Error)
+                        .that.has.property("message")
+                        .that.contains("404 Not Found");
+
+                    done();
+                });
+            });
+
+            it("handles error on a key/value hash of modules", (done) => {
+                getMissingComponentsUsingHash(location, (err, module) => {
+                    expect(err)
+                        .to.exist;
+
+                    expect(module)
+                        .to.not.exist;
+
+                    expect(err)
+                        .to.be.an.instanceof(Error)
+                        .that.has.property("message")
+                        .that.contains("404 Not Found");
+
+                    done();
+                });
+            });
+
+            it("handles error on an array of modules", (done) => {
+                getMissingComponentsUsingArray(location, (err, modules) => {
+                    expect(err)
+                        .to.exist;
+
+                    expect(modules)
+                        .to.not.exist;
+
+                    expect(err)
+                        .to.be.an.instanceof(Error)
+                        .that.has.property("message")
+                        .that.contains("404 Not Found");
+
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/AsyncExampleOne.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/AsyncExampleOne.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+class AsyncExampleOne extends React.Component {
+    render() {
+        return (
+            <div></div>
+        );
+    }
+}
+
+export default AsyncExampleOne;

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/AsyncExampleTwo.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/AsyncExampleTwo.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+class AsyncExampleTwo extends React.Component {
+    render() {
+        return (
+            <div></div>
+        );
+    }
+}
+
+export default AsyncExampleTwo;

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/routes.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/routes.js
@@ -1,0 +1,11 @@
+import ensure from "../../../index.js"; // eslint-disable-line import/default
+
+// React router route
+export const path = "/import-async-example";
+
+// Lazy loaded components
+export function getComponent(location, cb) {
+    return ensure("./AsyncExampleOne.js", module, (err, module) => {
+        return cb(err, module);
+    });
+}

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/routesArray.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/routesArray.js
@@ -1,0 +1,14 @@
+import ensure from "../../../index.js"; // eslint-disable-line import/default
+
+// React router route
+export const path = "/import-multi-async-example";
+
+// Lazy loaded components
+export function getComponents(location, cb) {
+    return ensure([
+        "./AsyncExampleOne.js",
+        "./AsyncExampleTwo.js"
+    ], module, (err, modules) => {
+        return cb(err, modules);
+    });
+}

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/routesHash.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/routesHash.js
@@ -1,0 +1,14 @@
+import ensure from "../../../index.js"; // eslint-disable-line import/default
+
+// React router route
+export const path = "/import-multi-async-example";
+
+// Lazy loaded components
+export function getComponents(location, cb) {
+    return ensure({
+        one: "./AsyncExampleOne.js",
+        two: "./AsyncExampleTwo.js"
+    }, module, (err, module) => {
+        return cb(err, module);
+    });
+}

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/routesMissing.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/routesMissing.js
@@ -1,0 +1,11 @@
+import ensure from "../../../index.js"; // eslint-disable-line import/default
+
+// React router route
+export const path = "/import-async-example";
+
+// Lazy loaded components
+export function getComponent(location, cb) {
+    return ensure("./AsyncErrorExample.js", module, (err, module) => {
+        return cb(err, module);
+    });
+}

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/routesMissingArray.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/routesMissingArray.js
@@ -1,0 +1,14 @@
+import ensure from "../../../index.js"; // eslint-disable-line import/default
+
+// React router route
+export const path = "/import-async-example";
+
+// Lazy loaded components
+export function getComponents(location, cb) {
+    return ensure([
+        "./AsyncErrorExampleOne.js",
+        "./AsyncErrorExampleTwo.js"
+    ], module, (err, modules) => {
+        return cb(err, modules);
+    });
+}

--- a/packages/react-wildcat-ensure/src/test/browser/fixtures/routesMissingHash.js
+++ b/packages/react-wildcat-ensure/src/test/browser/fixtures/routesMissingHash.js
@@ -1,0 +1,14 @@
+import ensure from "../../../index.js"; // eslint-disable-line import/default
+
+// React router route
+export const path = "/import-async-example";
+
+// Lazy loaded components
+export function getComponents(location, cb) {
+    return ensure({
+        one: "./AsyncErrorExampleOne.js",
+        two: "./AsyncErrorExampleTwo.js"
+    }, module, (err, module) => {
+        return cb(err, module);
+    });
+}

--- a/shell/install-example.sh
+++ b/shell/install-example.sh
@@ -10,7 +10,7 @@ for directory in packages/*; do
     if [ -d "${directory}" ]; then
         package=${directory##*/}
 
-        if [ -n "$(find "${directory}" -name "package.json" -depth 1 -print)" ]; then
+        if [ -f "${directory}/package.json" ]; then
             # Link module / package in example
             (
                 cd ${example};

--- a/shell/install-example.sh
+++ b/shell/install-example.sh
@@ -10,16 +10,18 @@ for directory in packages/*; do
     if [ -d "${directory}" ]; then
         package=${directory##*/}
 
-        # Link module / package in example
-        (
-            cd ${example};
+        if [ -n "$(find "${directory}" -type f -depth 1 -name "package.json" -print)" ]; then
+            # Link module / package in example
+            (
+                cd ${example};
 
-            # Link package to npm
-            npm link ${package};
+                # Link package to npm
+                npm link ${package};
 
-            # Link package to jspm
-            jspm install --link npm:${package}@${version} --log warn -y;
-        )
+                # Link package to jspm
+                jspm install --link npm:${package}@${version} --log warn -y;
+            )
+        fi
     fi
 
     echo "";

--- a/shell/install-example.sh
+++ b/shell/install-example.sh
@@ -10,7 +10,7 @@ for directory in packages/*; do
     if [ -d "${directory}" ]; then
         package=${directory##*/}
 
-        if [ -n "$(find "${directory}" -type f -depth 1 -name "package.json" -print)" ]; then
+        if [ -n "$(find "${directory}" -name "package.json" -depth 1 -print)" ]; then
             # Link module / package in example
             (
                 cd ${example};

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -10,7 +10,7 @@ for directory in packages/*; do
     if [ -d "${directory}" ]; then
         package=${directory##*/}
 
-        if [ -n "$(find "${directory}" -type f -depth 1 -name "package.json" -print)" ]; then
+        if [ -n "$(find "${directory}" -name "package.json" -depth 1 -print)" ]; then
             # Create module / package links
             (
                 cd ${directory};

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -10,32 +10,23 @@ for directory in packages/*; do
     if [ -d "${directory}" ]; then
         package=${directory##*/}
 
-        # Create module / package links
-        (
-            cd ${directory};
+        if [ -n "$(find "${directory}" -type f -depth 1 -name "package.json" -print)" ]; then
+            # Create module / package links
+            (
+                cd ${directory};
 
-            # react-wildcat-handoff depends on react-wildcat-radium
-            if [ "${package}" == "react-wildcat-handoff" ]; then
-                npm link "react-wildcat-radium";
-            fi
+                # react-wildcat-handoff depends on react-wildcat-radium
+                if [ "${package}" == "react-wildcat-handoff" ]; then
+                    npm link "react-wildcat-radium";
+                fi
 
-            # Link package to npm
-            npm link;
+                # Link package to npm
+                npm link;
 
-            # Link package to jspm
-            jspm link npm:${package}@${version} --log warn -y;
-        )
-
-        # Link module / package in example
-        (
-            cd ${example};
-
-            # Link package to npm
-            npm link ${package};
-
-            # Link package to jspm
-            jspm install --link npm:${package}@${version} --log warn -y;
-        )
+                # Link package to jspm
+                jspm link npm:${package}@${version} --log warn -y;
+            )
+        fi
     fi
 
     echo "";

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -10,7 +10,7 @@ for directory in packages/*; do
     if [ -d "${directory}" ]; then
         package=${directory##*/}
 
-        if [ -n "$(find "${directory}" -name "package.json" -depth 1 -print)" ]; then
+        if [ -f "${directory}/package.json" ]; then
             # Create module / package links
             (
                 cd ${directory};


### PR DESCRIPTION
A wrapper for [`System.import`](https://github.com/systemjs/systemjs) that behaves like Webpack's [`require.ensure`](https://webpack.github.io/docs/code-splitting.html#require-ensure):

- initial import calls are asynchronous
- subsequent import calls returns a synchronous cached import response

Designed for compatibility with React Router's [asynchronous route loading](https://github.com/rackt/react-router/blob/master/docs/guides/advanced/DynamicRouting.md).

## Usage

Importing a single module:

```js
import ensure from "react-wildcat-ensure";

// Lazy loaded component
export function getComponent(location, cb) {
    ensure("./AsyncComponent.js", module, (err, module) => {
        return cb(err, module);
    });
}
```

Importing a key/value hash of modules:

```js
import ensure from "react-wildcat-ensure";

// Lazy loaded index route
export function getIndexRoute(location, cb) {
    ensure({
      header: "./AsyncHeader.js",
      component: "./AsyncComponent.js"
    }, module, (err, modules) => {
        return cb(err, modules);
    });
}
```

Importing an array of modules:

```js
import ensure from "react-wildcat-ensure";

// Lazy loaded child routes
export function getChildRoutes(location, cb) {
    ensure([
      "./AsyncChildRouteOne.js",
      "./AsyncChildRouteTwo.js"
    ], module, (err, modules) => {
        return cb(err, modules);
    });
}
```
