### PR TITLE
Make https optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MAKEFLAGS = -j1
 
 export BABEL_ENV = test
 
-.PHONY: bootstrap clean install lint test test-browser-cov test-cov test-travis update-dependencies
+.PHONY: bootstrap clean install install-example lint test test-example test-browser-cov test-cov test-travis update-dependencies
 
 bootstrap:
 	npm install --silent

--- a/example/wildcat.config.js
+++ b/example/wildcat.config.js
@@ -33,14 +33,14 @@ var wildcatConfig = {
     },
 
     serverSettings: {
+        // Path to the entry config file relative to the project root
+        entry: "public/main.js",
+
+        // Path to the server renderer. This can be a jspm package or a relative path
+        renderHandler: "react-wildcat-handoff/server",
+
         // Directory to save raw binaries (jpg, gif, fonts, etc)
         binDir: "bin",
-
-        // An array of domains to allow for cross-origin requests
-        corsOrigins: [
-            "localhost",
-            "example.com"
-        ],
 
         // BYO-HTML template
         // htmlTemplate: require("./customHTMLTemplate.js"),
@@ -49,32 +49,87 @@ var wildcatConfig = {
         // https://www.npmjs.com/package/gelf-pro#configuration
         // graylog: {},
 
-        // Enable http2
-        http2: false,
-
-        // Enable https
-        https: true,
-
-        // Default port number
-        port: 3000,
-
-        // A key/value of urls to proxy
-        // e.g. /static -> http://example.com/static
-        proxies: {
-            "/static": "http://example.com/static"
-        },
-
         // Directory to output compiled JavaScript modules
         publicDir: "public",
 
-        // Path to the entry config file relative to the project root
-        entry: "public/main.js",
-
-        // Path to the server renderer. This can be a jspm package or a relative path
-        renderHandler: "react-wildcat-handoff/server",
-
         // Path to your source JavaScript files
-        sourceDir: "src"
+        sourceDir: "src",
+
+        // config options for the app server
+        appServer: {
+            // Enable http2
+            http2: true,
+
+            // Enable https
+            // Only applicable if http2 is false
+            // https: true,
+
+            // App server port
+            port: process.env.PORT || 3000,
+
+            // A key/value of urls to proxy
+            // e.g. /static -> http://example.com/static
+            proxies: {
+                "/static": "http://example.com/static"
+            }
+
+            // Only applicable when one of http2/https is true
+            // https://github.com/indutny/node-spdy#options
+            // secureSettings: {
+                // Provide your own key / cert / ca
+                // key: fs.readFileSync("./ssl/appServer.key"),
+                // cert: fs.readFileSync("./ssl/appServer.crt"),
+                // ca: fs.readFileSync("./ssl/appServer.csr"),
+
+                // If using http2, use the following protocols
+                // protocols: [
+                //     "h2",
+                //     "spdy/3.1",
+                //     "spdy/3",
+                //     "spdy/2",
+                //     "http/1.1",
+                //     "http/1.0"
+                // ]
+            // }
+        },
+
+        // config options for the static server
+        staticServer: {
+            // An array of domains to allow for cross-origin requests
+            corsOrigins: [
+                "localhost",
+                "example.com"
+            ],
+
+            // Enable http2
+            http2: true,
+
+            // Enable https
+            // Only applicable if http2 is false
+            // https: true,
+
+            // App server port
+            port: process.env.STATIC_PORT || 4000
+
+            // Only applicable when one of http2/https is true
+            // https://github.com/indutny/node-spdy#options
+            // secureSettings: {
+                // Provide your own key / cert / ca
+                // key: fs.readFileSync("./ssl/appServer.key"),
+                // cert: fs.readFileSync("./ssl/appServer.crt"),
+                // ca: fs.readFileSync("./ssl/appServer.csr"),
+
+                // If using http2, use the following protocols
+                // protocols: [
+                //     "h2",
+                //     "spdy/3.1",
+                //     "spdy/3",
+                //     "spdy/2",
+                //     "http/1.1",
+                //     "http/1.0"
+                // ]
+            // }
+        }
     }
 };
 

--- a/shell/clean-example.sh
+++ b/shell/clean-example.sh
@@ -13,7 +13,4 @@ example=example
 
     # Remove jspm packages
     rm -fr jspm_packages;
-
-    # spacer.gif
-    echo "";
 )

--- a/shell/clean.sh
+++ b/shell/clean.sh
@@ -16,9 +16,6 @@ for directory in packages/*; do
 
             # Remove jspm packages
             rm -fr jspm_packages;
-
-            # spacer.gif
-            echo "";
         )
     fi
 done

--- a/shell/install-example.sh
+++ b/shell/install-example.sh
@@ -21,8 +21,6 @@ for directory in packages/*; do
             jspm install --link npm:${package}@${version} --log warn -y;
         )
     fi
-
-    echo "";
 done
 
 # Install remaining modules / packages

--- a/shell/install.sh
+++ b/shell/install.sh
@@ -37,6 +37,4 @@ for directory in packages/*; do
             jspm install --link npm:${package}@${version} --log warn -y;
         )
     fi
-
-    echo "";
 done


### PR DESCRIPTION
## Summary
- Make https optional
- Allow devs to set custom security options
- Decouple appServer / staticServer settings
  - (e.g., you can now serve the app server using http and the static server using https)

## Test Plan

### Test 1:
- `make install`
- `cd example && npm run dev`

#### Expected:
- Site should be available at [https://localhost:3000](https://localhost:3000)

### Test 2:
- In `example/wildcat.config.js`, disable `http2`, enable `https`.

#### Expected:
- Site should be available at [https://localhost:3000](https://localhost:3000)

### Test 3:
- In `example/wildcat.config.js`, disable both `http2` and `https`.

#### Expected:
- Site should be available at [http://localhost:3000](http://localhost:3000)
