### PR TITLE
perf(react-wildcat): disable cache check in dev mode

### DIFF
--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -83,7 +83,8 @@ module.exports = function serverRender(cfg) {
                     });
 
                     result = Object.assign({}, result, {
-                        html: html
+                        html: html,
+                        status: 200
                     });
 
                     return resolve(result);

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -20,20 +20,19 @@ module.exports = function serverRender(cfg) {
     const request = cfg.request;
     const wildcatConfig = cfg.wildcatConfig;
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
         match(cfg, (error, redirectLocation, renderProps) => {
             let result = {};
+
+            if (error) {
+                return reject(error);
+            }
 
             if (redirectLocation) {
                 result = {
                     redirect: true,
                     redirectLocation,
                     status: 301
-                };
-            } else if (error) {
-                result = {
-                    error,
-                    status: 500
                 };
             } else if (!renderProps) {
                 result = {

--- a/packages/react-wildcat-handoff/test/serverHandoffSpec.js
+++ b/packages/react-wildcat-handoff/test/serverHandoffSpec.js
@@ -99,20 +99,16 @@ describe("react-wildcat-handoff/server", () => {
                 .that.equals("serverHandoff");
 
             const result = serverHandoff(stubs.requests.basic, stubs.cookieParser, stubs.wildcatConfig)
-                .then(response => {
-                    expect(response)
-                        .to.be.an("object")
-                        .that.has.property("error")
+                .catch(error => {
+                    expect(error)
+                        .to.exist;
+
+                    expect(error)
+                        .to.be.an("error")
                         .that.equals(stubs.callbackError);
 
-                    expect(response)
-                        .to.be.an("object")
-                        .that.has.property("status")
-                        .that.equals(500);
-
                     done();
-                })
-                .catch(error => done(error));
+                });
 
             expect(result)
                 .to.be.an.instanceof(Promise);
@@ -317,7 +313,7 @@ describe("react-wildcat-handoff/server", () => {
                     expect(response)
                         .to.be.an("object")
                         .that.has.property("error")
-                        .that.is.a("string")
+                        .that.is.an("error")
                         .that.equals(stubs.callbackError);
 
                     expect(response)

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -118,7 +118,7 @@ exports.routes = {
     )
 };
 
-exports.callbackError = "Fake Error!";
+exports.callbackError = new Error("Fake Error!");
 
 exports.invalidRoutes = {
     routes: React.createElement(

--- a/packages/react-wildcat/src/middleware/renderReactWithJSPM.js
+++ b/packages/react-wildcat/src/middleware/renderReactWithJSPM.js
@@ -117,12 +117,13 @@ module.exports = function renderReactWithJSPM(root, options) {
         response.type = "text/html";
         response.lastModified = file.lastModified || new Date().toGMTString();
 
+        const isFresh = (request.fresh || !__PROD__);
         var reply;
 
-        if (request.fresh && file.cache) {
+        if (isFresh && file.cache) {
             reply = file.cache;
         } else {
-            var data = yield pageHandler(request, cookies);
+            const data = yield pageHandler(request, cookies);
             reply = data.reply;
 
             // Save to cache

--- a/packages/react-wildcat/src/middleware/renderReactWithJSPM.js
+++ b/packages/react-wildcat/src/middleware/renderReactWithJSPM.js
@@ -126,13 +126,16 @@ module.exports = function renderReactWithJSPM(root, options) {
             const data = yield pageHandler(request, cookies);
             reply = data.reply;
 
-            // Save to cache
-            cache[request.url] = {
-                cache: reply,
-                lastModified: response.get("last-modified"),
-                packageCache: data.packageCache,
-                status: 304
-            };
+            // Only cache a successful response
+            if (reply.status >= 200 && reply.status < 400) {
+                // Save to cache
+                cache[request.url] = {
+                    cache: reply,
+                    lastModified: response.get("last-modified"),
+                    packageCache: data.packageCache,
+                    status: 304
+                };
+            }
         }
 
         if (reply.type) {

--- a/packages/react-wildcat/src/utils/blueBoxOfDeath.js
+++ b/packages/react-wildcat/src/utils/blueBoxOfDeath.js
@@ -72,7 +72,7 @@ module.exports = function (err, request) {
                 <p>An error occurred importing jspm packages for route <code>${request.url}</code>.</p>
                 <p>This is usually the result of attempting to load missing or invalid jspm package(s). Possible solutions:</p>
                 <ul>
-                    <li>Check your console for 404 status codes. These should identify missing packages or modules.</li>
+                    <li>Check your console for <code>40x</code> or <code>50x</code> status codes. These should identify missing packages or modules.</li>
                     <li>Run <code>jspm install</code> to install any missing dependencies.</li>
                 </ul>
             </div>


### PR DESCRIPTION
This fix disables the check against the  header in development mode, and always
serves the server-side render from cache. This improves performance during development while devs
have browser cache disabled. The WebSocket file change listener still behaves as usual and will
still expire route caches when necessary, so devs will still see fresh data when necessary.