### PR TITLE
perf(react-wildcat): store cache data in a weak map

### DIFF
--- a/packages/react-wildcat/src/middleware/renderReactWithJSPM.js
+++ b/packages/react-wildcat/src/middleware/renderReactWithJSPM.js
@@ -4,7 +4,7 @@ module.exports = function renderReactWithJSPM(root, options) {
     const jspm = require("jspm");
     const __PROD__ = (process.env.NODE_ENV === "production");
 
-    const cache = options.cache;
+    const routeCache = options.cache;
     const wildcatConfig = options.wildcatConfig;
 
     function customizeJSPMLoader() {
@@ -115,7 +115,7 @@ module.exports = function renderReactWithJSPM(root, options) {
         const request = this.request;
         const response = this.response;
 
-        const file = cache[request.url] || {};
+        const file = routeCache.get(request.url) || {};
 
         response.status = 200;
         response.type = "text/html";
@@ -133,12 +133,12 @@ module.exports = function renderReactWithJSPM(root, options) {
             // Only cache a successful response
             if (reply.status >= 200 && reply.status < 400) {
                 // Save to cache
-                cache[request.url] = {
+                routeCache.set(request.url, {
                     cache: reply,
                     lastModified: response.get("last-modified"),
                     packageCache: data.packageCache,
                     status: 304
-                };
+                });
             }
         }
 

--- a/packages/react-wildcat/src/server.js
+++ b/packages/react-wildcat/src/server.js
@@ -36,7 +36,7 @@ function start() {
     const appServerSettings = serverSettings.appServer;
     const secureSettings = appServerSettings.secureSettings;
 
-    const routeCache = {};
+    const routeCache = new Map();
     const morganOptions = getMorganOptions(generalSettings.logLevel);
 
     const __PROD__ = (process.env.NODE_ENV === "production");

--- a/packages/react-wildcat/src/utils/connectToWebSocketServer.js
+++ b/packages/react-wildcat/src/utils/connectToWebSocketServer.js
@@ -39,12 +39,12 @@ module.exports = function connectToWebSocketServer(options) {
 
         switch (message.event) {
             case "filechange":
-                Object.keys(routeCache).forEach(function cacheCheck(route) {
-                    const routePackageCache = routeCache[route].packageCache;
+                routeCache.forEach(function cacheCheck(routeData, routeName) {
+                    const routePackageCache = routeData.packageCache;
 
                     if (Array.isArray(routePackageCache) && routePackageCache.indexOf(modulePath) !== -1) {
-                        logger.info(`expiring cache for`, route, cluster.worker.id);
-                        delete routeCache[route];
+                        logger.info(`expiring cache for`, routeData, cluster.worker.id);
+                        routeCache.delete(routeName);
                     }
                 });
                 break;

--- a/packages/react-wildcat/test/appServerSpec.js
+++ b/packages/react-wildcat/test/appServerSpec.js
@@ -238,7 +238,7 @@ describe("react-wildcat", () => {
 
                 const renderTypes = [{
                     name: "renders HTML",
-                    cache: {},
+                    cache: new Map(),
                     fresh: false,
                     reply: {
                         reply: stubResponses["200"]
@@ -246,11 +246,11 @@ describe("react-wildcat", () => {
                     url: "/"
                 }, {
                     name: "returns HTML from cache",
-                    cache: {
-                        "/": {
+                    cache: new Map([
+                        ["/", {
                             cache: stubResponses["304"]
-                        }
-                    },
+                        }]
+                    ]),
                     fresh: true,
                     reply: {
                         reply: stubResponses["304"]
@@ -258,7 +258,7 @@ describe("react-wildcat", () => {
                     url: "/"
                 }, {
                     name: "returns error payload",
-                    cache: {},
+                    cache: new Map(),
                     fresh: false,
                     reply: {
                         reply: stubResponses["404"]
@@ -266,7 +266,7 @@ describe("react-wildcat", () => {
                     url: "/error"
                 }, {
                     name: "redirects the page",
-                    cache: {},
+                    cache: new Map(),
                     fresh: false,
                     reply: {
                         reply: stubResponses["301"]
@@ -344,7 +344,7 @@ describe("react-wildcat", () => {
 
                 it("renders HTML", (done) => {
                     const renderReactWithJSPM = require("../src/middleware/renderReactWithJSPM")(exampleDir, {
-                        cache: {},
+                        cache: new Map(),
                         wildcatConfig
                     });
 


### PR DESCRIPTION
Using Weak Maps to store cache data, which should perform faster than a basic object hash. (Source:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)