### PR TITLE
fix(react-wildcat-handoff): Add workaround for navigator.userAgent requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
       "cookies-js": "^1.2.2",
       "debounce": "^1.0.0",
       "exenv": "^1.2.0",
-      "history": "^1.13.1",
+      "history": "1.13.1",
       "hoist-non-react-statics": "^1.0.3",
       "invariant": "^2.2.0",
       "isomorphic-fetch": "^2.2.0",

--- a/packages/react-wildcat-handoff/package.json
+++ b/packages/react-wildcat-handoff/package.json
@@ -7,7 +7,7 @@
     "cookies-js": "^1.2.2",
     "debounce": "^1.0.0",
     "exenv": "^1.2.0",
-    "history": "^1.13.1",
+    "history": "1.13.1",
     "isomorphic-fetch": "^2.2.0",
     "match-media-mock": "^0.1.0",
     "parse-domain": "^0.2.0",

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -52,6 +52,12 @@ module.exports = function serverRender(cfg) {
                         })
                 )
                     .then(function serverRenderPromiseResult() {
+                        // FIXME: Remove this workaround when this issue is resolved:
+                        // https://github.com/callemall/material-ui/pull/2007
+                        global.navigator = global.navigator || {
+                            userAgent: request.header["user-agent"]
+                        };
+
                         const reactMarkup = ReactDOM.renderToString(
                             serverContext(request, cookies, renderProps)
                         );


### PR DESCRIPTION
Workaround for the Material UI server-side navigator.userAgent requirement.