### PR TITLE
fix(react-wildcat-handoff): reject Promise if error is found

### DIFF
--- a/packages/react-wildcat-handoff/src/server.js
+++ b/packages/react-wildcat-handoff/src/server.js
@@ -32,13 +32,10 @@ function render(cfg) {
         });
 
         if (!cfg.routes && cfg.domains) {
-            return new Promise((resolve) => {
+            return new Promise((resolve, reject) => {
                 getDomainRoutes(cfg.domains, header, (error, routes) => {
                     if (error) {
-                        return resolve({
-                            error,
-                            status: 500
-                        });
+                        return reject(error);
                     }
 
                     return resolve(completeRender(cfg, routes));

--- a/packages/react-wildcat-handoff/test/serverHandoffSpec.js
+++ b/packages/react-wildcat-handoff/test/serverHandoffSpec.js
@@ -309,21 +309,10 @@ describe("react-wildcat-handoff/server", () => {
                 .that.equals("serverHandoff");
 
             const result = serverHandoff(stubs.requests.err, stubs.cookieParser, stubs.wildcatConfig)
-                .then(response => {
-                    expect(response)
-                        .to.be.an("object")
-                        .that.has.property("error")
-                        .that.is.an("error")
-                        .that.equals(stubs.callbackError);
-
-                    expect(response)
-                        .to.be.an("object")
-                        .that.has.property("status")
-                        .that.equals(500);
-
+                .catch(e => {
+                    expect(e).to.be.an.instanceof(Error);
                     done();
-                })
-                .catch(error => done(error));
+                });
 
             expect(result)
                 .to.be.an.instanceof(Promise);


### PR DESCRIPTION
Trigger a Promise rejection if an error is thrown.