### PR TITLE
refactor(react-wildcat-hot-reloader): make hot reloading configurable

### DIFF
--- a/example/wildcat.config.js
+++ b/example/wildcat.config.js
@@ -1,4 +1,5 @@
-var pkg = require("./package.json");
+const pkg = require("./package.json");
+const __PROD__ = (process.env.NODE_ENV === "production");
 
 function getPort(port, defaultPort) {
     if ((typeof port !== "undefined") && !(Number(port))) {
@@ -17,7 +18,7 @@ const excludes = [
 ];
 
 /* istanbul ignore next */
-var wildcatConfig = {
+const wildcatConfig = {
     generalSettings: {
         // Grab the config file from package.json
         jspmConfigFile: pkg.configFile || (pkg.jspm || {}).configFile || "config.js",
@@ -70,6 +71,8 @@ var wildcatConfig = {
         // Path to the entry config file relative to the project root
         entry: "public/main.js",
 
+        hotReload: !__PROD__,
+
         // Path to the client renderer. This can be a jspm package or a relative path
         renderHandler: "react-wildcat-handoff/client",
 
@@ -80,6 +83,8 @@ var wildcatConfig = {
     serverSettings: {
         // Path to the entry config file relative to the project root
         entry: "public/main.js",
+
+        hotReload: !__PROD__,
 
         // Path to the server renderer. This can be a jspm package or a relative path
         renderHandler: "react-wildcat-handoff/server",

--- a/packages/react-wildcat-handoff/src/utils/defaultTemplate.js
+++ b/packages/react-wildcat-handoff/src/utils/defaultTemplate.js
@@ -10,12 +10,12 @@ module.exports = function defaultTemplate(cfg) {
     const generalSettings = wildcatConfig.generalSettings;
 
     const entry = clientSettings.entry;
+    const hotReload = clientSettings.hotReload;
+    const hotReloader = clientSettings.hotReloader;
     const renderHandler = clientSettings.renderHandler;
     const reactRootElementID = clientSettings.reactRootElementID;
     const staticUrl = generalSettings.staticUrl;
     const socketUrl = staticUrl.replace("http", "ws");
-
-    const __DEV__ = (typeof process !== "undefined") && (process.env.NODE_ENV === "development");
 
     return `
 <!doctype html>
@@ -39,7 +39,7 @@ module.exports = function defaultTemplate(cfg) {
         <script>
             System.config({
                 baseURL: "${staticUrl}",
-                trace: ${__DEV__}
+                trace: ${hotReload}
             });
         </script>
 
@@ -67,15 +67,15 @@ module.exports = function defaultTemplate(cfg) {
         <script>
             Promise.all([
                 System.import("${entry}"),
-                System.import("${renderHandler}")${__DEV__ ? `,
-                System.import("react-wildcat-hot-reloader")` : ``}
+                System.import("${renderHandler}")${hotReload ? `,
+                System.import("${hotReloader}")` : ``}
             ])
                 .then(function clientEntry(responses) {
                     // First response is a hash of project options
                     var clientOptions = responses[0];
 
                     // Second response is the handoff to the client
-                    var client = responses[1];${__DEV__ ? `
+                    var client = responses[1];${hotReload ? `
 
                     // Third response is our hot reloader
                     var HotReloader = responses[2];

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -86,10 +86,15 @@ exports.wildcatConfig = {
     },
     clientSettings: {
         entry: "public/main.js",
+        hotReload: true,
+        hotReloader: "react-wildcat-hot-reloader",
         reactRootElementID: "content",
         renderHandler: "react-wildcat-handoff/client"
     },
-    serverSettings: {}
+    serverSettings: {
+        hotReload: true,
+        hotReloader: "react-wildcat-hot-reloader"
+    }
 };
 
 exports.Application = React.createClass({

--- a/packages/react-wildcat-hot-reloader/package.json
+++ b/packages/react-wildcat-hot-reloader/package.json
@@ -5,8 +5,7 @@
   "main": "src",
   "dependencies": {
     "debug": "^2.2.0",
-    "exenv": "^1.2.0",
-    "ws": "^0.8.1"
+    "exenv": "^1.2.0"
   },
   "jspm": {
     "directories": {

--- a/packages/react-wildcat-hot-reloader/src/index.js
+++ b/packages/react-wildcat-hot-reloader/src/index.js
@@ -50,7 +50,7 @@ HotReloader.prototype = {
                         return f.name === failedDependency.value;
                     });
                 });
-            })[0];
+            });
 
         failedModuleDependencies.forEach(function withFailedDependency(failedDependency) {
             var normalizedDependencyName = failedDependency.value;

--- a/packages/react-wildcat-hot-reloader/src/index.js
+++ b/packages/react-wildcat-hot-reloader/src/index.js
@@ -7,18 +7,15 @@ var ExecutionEnvironment = require("exenv");
 var debug = require("debug");
 var d = debug("jspm-hot-reloader");
 
-// WebSocket polyfill for Node
-var NodeWebSocket = require("ws/lib/WebSocket.js");
-
-function HotReloader(socketUrl, customLoader) {
+function HotReloader(customLoader) {
     this.Loader = customLoader || System;
     this.originalImportFn = this.Loader.import;
 
-    return this.init(socketUrl);
+    return this.init();
 }
 
 HotReloader.prototype = {
-    init: function init(socketUrl) {
+    init: function init() {
         var self = this;
 
         self.clientImportedModules = [];
@@ -36,28 +33,6 @@ HotReloader.prototype = {
                 }
             );
         };
-
-        var Socket = (typeof WebSocket !== "undefined") ? WebSocket : NodeWebSocket;
-        var socket = new Socket(socketUrl);
-
-        socket.addEventListener("open", function socketOpen() {
-            console.info(`Listening to socket server at ${socketUrl}.`);
-        });
-
-        socket.addEventListener("error", function socketError() {
-            console.warn(`No socket server found at ${socketUrl}.`);
-        });
-
-        socket.addEventListener("message", function socketMessage(messageEvent) {
-            var message = JSON.parse(messageEvent.data);
-            var moduleName = message.data;
-
-            switch (message.event) {
-                case "filechange":
-                    self.onFileChanged.call(self, moduleName);
-                    break;
-            }
-        });
 
         self.pushImporters(self.Loader.loads);
     },

--- a/packages/react-wildcat-hot-reloader/src/index.js
+++ b/packages/react-wildcat-hot-reloader/src/index.js
@@ -70,6 +70,9 @@ HotReloader.prototype = {
     onFileChanged: function onFileChanged(moduleName) {
         var self = this;
 
+        // Refresh current modules
+        self.pushImporters(self.Loader.loads, false, true);
+
         if (ExecutionEnvironment.canUseDOM && moduleName === "index.html") {
             document.location.reload(true);
         } else {
@@ -100,7 +103,7 @@ HotReloader.prototype = {
         }
     },
 
-    pushImporters: function pushImporters(moduleMap, overwriteOlds) {
+    pushImporters: function pushImporters(moduleMap, overwriteOlds, onlyNewRefs) {
         var self = this;
 
         if (!moduleMap) {
@@ -112,6 +115,8 @@ HotReloader.prototype = {
 
             if (!mod.importers) {
                 mod.importers = [];
+            } else if (onlyNewRefs) {
+                return;
             }
 
             mod.deps.forEach(function cacheDependantImporters(dependantName) {
@@ -245,7 +250,7 @@ HotReloader.prototype = {
                     });
                 }
 
-                if (module.importers.length === 0) {
+                if (typeof module.importers === "undefined" || module.importers.length === 0) {
                     toReimport.push(module.name);
                 } else {
                     var deleted = deleteAllImporters(module);

--- a/packages/react-wildcat/package.json
+++ b/packages/react-wildcat/package.json
@@ -40,7 +40,7 @@
     "resolve-path": "^1.3.0",
     "slash": "^1.0.0",
     "spdy": "^3.0.0",
-    "ws": "^0.8.0"
+    "ws": "^0.8.1"
   },
   "scripts": {
     "test": "echo \"no test specified\" && exit 0"

--- a/packages/react-wildcat/src/middleware/renderReactWithJspm.js
+++ b/packages/react-wildcat/src/middleware/renderReactWithJspm.js
@@ -2,6 +2,7 @@ module.exports = function renderReactWithJspm(root, options) {
     "use strict";
 
     const customLoader = require("../utils/customJspmLoader")(root);
+    const hotReloaderWebSocket = require("../utils/hotReloaderWebSocket");
     const __PROD__ = (process.env.NODE_ENV === "production");
 
     const wildcatConfig = options.wildcatConfig;
@@ -27,7 +28,9 @@ module.exports = function renderReactWithJspm(root, options) {
                 const HotReloader = responses[1];
 
                 if (HotReloader) {
-                    new HotReloader(generalSettings.staticUrl.replace(/http/, "ws"), customLoader);
+                    const hotReloader = new HotReloader(customLoader);
+                    const socketUrl = generalSettings.staticUrl.replace(/http/, "ws");
+                    hotReloaderWebSocket(hotReloader, socketUrl);
                 }
 
                 // FIXME: Possibly not needed in jspm 0.17

--- a/packages/react-wildcat/src/utils/customJspmLoader.js
+++ b/packages/react-wildcat/src/utils/customJspmLoader.js
@@ -4,16 +4,15 @@ const jspm = require("jspm");
 const baseURL = require("./baseURI");
 
 let customLoader;
-const __PROD__ = (process.env.NODE_ENV === "production");
 
-module.exports = function customJspmLoader(root) {
+module.exports = function customJspmLoader(root, wildcatConfig) {
     if (!customLoader) {
         jspm.setPackagePath(root);
 
         customLoader = jspm.Loader();
         customLoader.baseURL = baseURL;
 
-        if (!__PROD__) {
+        if (wildcatConfig.serverSettings.hotReload) {
             customLoader.trace = true;
         }
     }

--- a/packages/react-wildcat/src/utils/hotReloaderWebSocket.js
+++ b/packages/react-wildcat/src/utils/hotReloaderWebSocket.js
@@ -1,0 +1,25 @@
+// WebSocket polyfill for Node
+const WebSocket = require("ws/lib/WebSocket.js");
+
+module.exports = function hotReloaderWebSocket(hotReloader, socketUrl) {
+    var socket = new WebSocket(socketUrl);
+
+    socket.addEventListener("open", function socketOpen() {
+        console.info(`Listening to socket server at ${socketUrl}.`);
+    });
+
+    socket.addEventListener("error", function socketError() {
+        console.warn(`No socket server found at ${socketUrl}.`);
+    });
+
+    socket.addEventListener("message", function socketMessage(messageEvent) {
+        var message = JSON.parse(messageEvent.data);
+        var moduleName = message.data;
+
+        switch (message.event) {
+            case "filechange":
+                hotReloader.onFileChanged.call(hotReloader, moduleName);
+                break;
+        }
+    });
+};

--- a/packages/react-wildcat/src/utils/templates/wildcat.config.js
+++ b/packages/react-wildcat/src/utils/templates/wildcat.config.js
@@ -9,6 +9,8 @@ const defaultServerKey = getDefaultSSLFile("server.key");
 const defaultServerCert = getDefaultSSLFile("server.crt");
 const defaultServerCA = getDefaultSSLFile("server.csr");
 
+const __PROD__ = (process.env.NODE_ENV === "production");
+
 /* istanbul ignore next */
 const wildcatConfig = {
     generalSettings: {
@@ -64,6 +66,9 @@ const wildcatConfig = {
         // Path to the entry config file relative to the project root
         entry: "public/main.js",
 
+        hotReload: !__PROD__,
+        hotReloader: "react-wildcat-hot-reloader",
+
         // Path to the client renderer. This can be a jspm package or a relative path
         renderHandler: "react-wildcat-handoff/client",
 
@@ -80,6 +85,10 @@ const wildcatConfig = {
 
         // Directory to save raw binaries (jpg, gif, fonts, etc)
         binDir: "bin",
+
+        hotReload: !__PROD__,
+        hotReloader: "react-wildcat-hot-reloader",
+        hotReloadReporter: undefined,
 
         // BYO-HTML template
         // htmlTemplate: require("./customHTMLTemplate.js"),


### PR DESCRIPTION
This pull request allows devs to provide custom hot-reloading solutions. The default functionality uses WebSockets, but devs can now integrate with other reporting tools such as [Kafka](kafka.apache.org).