### PR TITLE
feat(react-wildcat-handoff): support for ephemeral subdomains

### DIFF
--- a/packages/react-wildcat-handoff/test/serverHandoffSpec.js
+++ b/packages/react-wildcat-handoff/test/serverHandoffSpec.js
@@ -220,6 +220,65 @@ describe("react-wildcat-handoff/server", () => {
             });
         });
 
+        context("matches ephemeral subdomains", () => {
+            ["async", "sync"].forEach((timing) => {
+                it(timing, (done) => {
+                    const serverHandoff = server(stubs.subdomains[timing]);
+
+                    expect(serverHandoff)
+                        .to.be.a("function")
+                        .that.has.property("name")
+                        .that.equals("serverHandoff");
+
+                    const result = serverHandoff(stubs.requests.ephemeral, stubs.cookieParser, stubs.wildcatConfig)
+                        .then(response => {
+                            expect(response)
+                                .to.be.an("object")
+                                .that.has.property("html")
+                                .that.is.a("string");
+
+                            done();
+                        })
+                        .catch(error => done(error));
+
+                    expect(result)
+                        .to.be.an.instanceof(Promise);
+                });
+            });
+        });
+
+        context("handles subdomain matching errors", () => {
+            ["async", "sync"].forEach((timing) => {
+                it(timing, (done) => {
+                    const serverHandoff = server(stubs.subdomains[timing]);
+
+                    expect(serverHandoff)
+                        .to.be.a("function")
+                        .that.has.property("name")
+                        .that.equals("serverHandoff");
+
+                    const result = serverHandoff(stubs.requests.invalidSubdomain, stubs.cookieParser, stubs.wildcatConfig)
+                        .then(response => {
+                            expect(response)
+                                .to.be.an("object")
+                                .that.has.property("error")
+                                .that.is.a("string");
+
+                            expect(response)
+                                .to.be.an("object")
+                                .that.has.property("status")
+                                .that.equals(404);
+
+                            done();
+                        })
+                        .catch(error => done(error));
+
+                    expect(result)
+                        .to.be.an.instanceof(Promise);
+                });
+            });
+        });
+
         context("defaults to www when no subdomain is provided", () => {
             ["async", "sync"].forEach((timing) => {
                 it(timing, (done) => {

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -13,6 +13,14 @@ exports.requests = {
         url: "/"
     },
 
+    ephemeral: {
+        header: {
+            host: "www-staging.example.com",
+            "user-agent": exports.stubUserAgent
+        },
+        url: "/"
+    },
+
     err: {
         header: {
             host: "err.example.com",
@@ -27,6 +35,14 @@ exports.requests = {
             "user-agent": exports.stubUserAgent
         },
         url: "/this-route-does-not-exist"
+    },
+
+    invalidSubdomain: {
+        header: {
+            host: "wwwstaging.example.com",
+            "user-agent": exports.stubUserAgent
+        },
+        url: "/"
     },
 
     noSubdomain: {


### PR DESCRIPTION
Support temporary subdomains. Useful for staging environments, i.e. using www-staging.example.com to
test the www subdomain, or staging-foo.example.com to test the foo subdomain, etc.