### PR TITLE
chore: Updated babel-eslint to 4.1.7

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "rimraf": "^2.5.1"
   },
   "devDependencies": {
-    "babel-eslint": "^4.1.5",
+    "babel-eslint": "^4.1.7",
     "babel-plugin-react-transform": "^1.1.1",
     "babel-runtime": "^5.8.25",
     "chai": "^3.5.0",

--- a/example/src/components/Application/Application.js
+++ b/example/src/components/Application/Application.js
@@ -17,11 +17,11 @@ class Application extends React.Component {
         radiumConfig: React.PropTypes.shape({
             userAgent: React.PropTypes.string
         })
-    }
+    };
 
     static propTypes = {
         children: React.PropTypes.any
-    }
+    };
 
     render() {
         const {radiumConfig} = this.context;

--- a/example/src/routes/PrefetchExample/PrefetchExample.js
+++ b/example/src/routes/PrefetchExample/PrefetchExample.js
@@ -7,13 +7,13 @@ import {nflCDN} from "application.config.js";
 class PrefetchExample extends React.Component {
     static propTypes = {
         asyncData: React.PropTypes.object.isRequired
-    }
+    };
 
     static defaultProps = {
         asyncData: {
             superBowls: []
         }
-    }
+    };
 
     render() {
         const {asyncData: {superBowls}} = this.props;

--- a/example/src/test/e2e/objects/ErrorPageObject.js
+++ b/example/src/test/e2e/objects/ErrorPageObject.js
@@ -6,12 +6,12 @@ const {originUrl} = browser.params;
 const dom = Symbol("dom");
 
 class ErrorPageObject {
-    static location = `${originUrl}/error-example`
+    static location = `${originUrl}/error-example`;
 
     _dom = {
         container: $("#error"),
         link: $("#error-link")
-    }
+    };
 
     get [dom]() {
         return this._dom;

--- a/example/src/test/e2e/objects/FlexboxPageObject.js
+++ b/example/src/test/e2e/objects/FlexboxPageObject.js
@@ -6,12 +6,12 @@ const {maxTimeout, originUrl} = browser.params;
 const dom = Symbol("dom");
 
 class FlexboxPageObject {
-    static location = `${originUrl}/flexbox-example`
+    static location = `${originUrl}/flexbox-example`;
 
     _dom = {
         container: $("#flexbox"),
         link: $("#flexbox-link")
-    }
+    };
 
     get [dom]() {
         return this._dom;

--- a/example/src/test/e2e/objects/HelmetPageObject.js
+++ b/example/src/test/e2e/objects/HelmetPageObject.js
@@ -6,12 +6,12 @@ const {maxTimeout, originUrl} = browser.params;
 const dom = Symbol("dom");
 
 class HelmetPageObject {
-    static location = `${originUrl}/helmet-example`
+    static location = `${originUrl}/helmet-example`;
 
     _dom = {
         container: $("#helmet"),
         link: $("#helmet-link")
-    }
+    };
 
     get [dom]() {
         return this._dom;

--- a/example/src/test/e2e/objects/IndexPageObject.js
+++ b/example/src/test/e2e/objects/IndexPageObject.js
@@ -6,13 +6,13 @@ const {maxTimeout, originUrl} = browser.params;
 const dom = Symbol("dom");
 
 class IndexPageObject {
-    static location = `${originUrl}/`
+    static location = `${originUrl}/`;
 
     _dom = {
         container: $(`#index`),
         link: $(`#index-link`),
         navigationLinks: $$(`[role="navigation"] a`)
-    }
+    };
 
     get [dom]() {
         return this._dom;

--- a/example/src/test/e2e/objects/PrefetchPageObject.js
+++ b/example/src/test/e2e/objects/PrefetchPageObject.js
@@ -6,12 +6,12 @@ const {maxTimeout, originUrl} = browser.params;
 const dom = Symbol("dom");
 
 class PrefetchPageObject {
-    static location = `${originUrl}/prefetch-example`
+    static location = `${originUrl}/prefetch-example`;
 
     _dom = {
         container: $("#prefetch"),
         link: $("#prefetch-link")
-    }
+    };
 
     get [dom]() {
         return this._dom;

--- a/example/src/test/e2e/utils/contextStub.js
+++ b/example/src/test/e2e/utils/contextStub.js
@@ -1,5 +1,5 @@
 const contextStub = {
-    router: () => {
+    router: (() => {
         const routerStub = sinon.stub();
         routerStub.getRouteAtDepth = sinon.stub();
         routerStub.setRouteComponentAtDepth = sinon.stub();
@@ -8,7 +8,7 @@ const contextStub = {
         routerStub.isActive = sinon.stub();
 
         return routerStub;
-    }(),
+    })(),
     routeDepth: 1
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "engineers@nfl.com",
   "license": "MIT",
   "devDependencies": {
-    "babel-eslint": "^4.1.6",
+    "babel-eslint": "^4.1.7",
     "chai": "^3.4.0",
     "co": "^4.6.0",
     "codecov.io": "^0.1.6",

--- a/packages/react-wildcat-prefetch/src/test/browser/fixtures/HelloES7.js
+++ b/packages/react-wildcat-prefetch/src/test/browser/fixtures/HelloES7.js
@@ -8,11 +8,11 @@ class Hello extends React.Component {
     static propTypes = {
         count: React.PropTypes.number,
         title: React.PropTypes.string
-    }
+    };
 
     static defaultProps = {
         count: 0
-    }
+    };
 
     static staticMethod() {
         return 42;

--- a/packages/react-wildcat-prefetch/src/test/browser/prefetchSpec.js
+++ b/packages/react-wildcat-prefetch/src/test/browser/prefetchSpec.js
@@ -304,11 +304,11 @@ describe("react-wildcat-prefetch", () => {
                 class WindowHydrationTest extends React.Component {
                     static propTypes = {
                         asyncData: React.PropTypes.object
-                    }
+                    };
 
                     static defaultProps = {
                         asyncData: {}
-                    }
+                    };
 
                     render() {
                         expect(this.props.asyncData)
@@ -328,11 +328,11 @@ describe("react-wildcat-prefetch", () => {
                 class ArrayHydrationTest extends React.Component {
                     static propTypes = {
                         asyncArrayData: React.PropTypes.array
-                    }
+                    };
 
                     static defaultProps = {
                         asyncArrayData: []
-                    }
+                    };
 
                     render() {
                         expect(this.props.asyncArrayData)
@@ -354,11 +354,11 @@ describe("react-wildcat-prefetch", () => {
                 class FirstHydrationTest extends React.Component {
                     static propTypes = {
                         firstData: React.PropTypes.object
-                    }
+                    };
 
                     static defaultProps = {
                         firstData: {}
-                    }
+                    };
 
                     render() {
                         expect(this.props.firstData)
@@ -376,11 +376,11 @@ describe("react-wildcat-prefetch", () => {
                 class SecondHydrationTest extends React.Component {
                     static propTypes = {
                         secondData: React.PropTypes.object
-                    }
+                    };
 
                     static defaultProps = {
                         secondData: {}
-                    }
+                    };
 
                     render() {
                         expect(this.props.secondData)
@@ -429,11 +429,11 @@ describe("react-wildcat-prefetch", () => {
                     class CustomKeyHydrationTest extends React.Component {
                         static propTypes = {
                             [stubs.prefetchedDataKey]: React.PropTypes.object
-                        }
+                        };
 
                         static defaultProps = {
                             [stubs.prefetchedDataKey]: {}
-                        }
+                        };
 
                         render() {
                             expect(this.props[stubs.prefetchedDataKey])
@@ -455,11 +455,11 @@ describe("react-wildcat-prefetch", () => {
                     class CustomKeyHydrationTest extends React.Component {
                         static propTypes = {
                             [stubs.prefetchedDataKey]: React.PropTypes.object
-                        }
+                        };
 
                         static defaultProps = {
                             [stubs.prefetchedDataKey]: {}
-                        }
+                        };
 
                         render() {
                             expect(this.props[stubs.prefetchedDataKey])
@@ -480,11 +480,11 @@ describe("react-wildcat-prefetch", () => {
                 class MemoryHydrationTest extends React.Component {
                     static propTypes = {
                         asyncData: React.PropTypes.object
-                    }
+                    };
 
                     static defaultProps = {
                         asyncData: {}
-                    }
+                    };
 
                     render() {
                         expect(this.props.asyncData)
@@ -529,7 +529,7 @@ describe("react-wildcat-prefetch", () => {
                 class RehydrationTest extends React.Component {
                     static propTypes = {
                         asyncData: React.PropTypes.object
-                    }
+                    };
 
                     render() {
                         if (renderCount === 1) {
@@ -558,7 +558,7 @@ describe("react-wildcat-prefetch", () => {
                 class ArrayRehydrationTest extends React.Component {
                     static propTypes = {
                         asyncArrayData: React.PropTypes.array
-                    }
+                    };
 
                     render() {
                         if (renderCount === 1) {
@@ -589,11 +589,11 @@ describe("react-wildcat-prefetch", () => {
                 class FirstRehydrationTest extends React.Component {
                     static propTypes = {
                         firstData: React.PropTypes.object
-                    }
+                    };
 
                     static defaultProps = {
                         firstData: {}
-                    }
+                    };
 
                     render() {
                         if (firstRenderCount === 1) {
@@ -619,11 +619,11 @@ describe("react-wildcat-prefetch", () => {
                 class SecondRehydrationTest extends React.Component {
                     static propTypes = {
                         secondData: React.PropTypes.object
-                    }
+                    };
 
                     static defaultProps = {
                         secondData: {}
-                    }
+                    };
 
                     render() {
                         if (secondRenderCount === 1) {

--- a/packages/react-wildcat-test-runners/src/karma.js
+++ b/packages/react-wildcat-test-runners/src/karma.js
@@ -26,7 +26,7 @@ const staticUrl = url.format({
 const args = process.argv.slice(2).join(` `).trim();
 
 /* eslint-disable no-process-exit */
-export default async () => {
+export default (async () => {
     try {
         const staticOrigin = staticUrl;
         const shouldStartStaticServer = await checkServerStatus(staticOrigin);
@@ -65,4 +65,4 @@ export default async () => {
     } catch (e) {
         process.exit(e);
     }
-}();
+})();

--- a/packages/react-wildcat-test-runners/src/protractor.js
+++ b/packages/react-wildcat-test-runners/src/protractor.js
@@ -33,7 +33,7 @@ const staticUrl = url.format({
 const args = process.argv.slice(2).join(` `).trim();
 
 /* eslint-disable no-process-exit */
-export default async () => {
+export default (async () => {
     try {
         const origin = originUrl;
         const shouldStartLocalServer = await checkServerStatus(origin);
@@ -81,4 +81,4 @@ export default async () => {
     } catch (e) {
         process.exit(e);
     }
-}();
+})();

--- a/packages/react-wildcat/test/appServerSpec.js
+++ b/packages/react-wildcat/test/appServerSpec.js
@@ -176,7 +176,7 @@ describe("react-wildcat", () => {
 
                         return config;
                     },
-                    "./utils/logger": () => {
+                    "./utils/logger": (() => {
                         function Logger() {}
 
                         Logger.prototype = {
@@ -187,7 +187,7 @@ describe("react-wildcat", () => {
                         };
 
                         return Logger;
-                    }()
+                    })()
                 });
 
                 staticServer.start()
@@ -463,7 +463,7 @@ describe("react-wildcat", () => {
 
                                 return defaultConfig;
                             },
-                            "./utils/logger": () => {
+                            "./utils/logger": (() => {
                                 function Logger() {}
 
                                 Logger.prototype = {
@@ -474,7 +474,7 @@ describe("react-wildcat", () => {
                                 };
 
                                 return Logger;
-                            }()
+                            })()
                         });
 
                         expect(server)

--- a/packages/react-wildcat/test/staticServerSpec.js
+++ b/packages/react-wildcat/test/staticServerSpec.js
@@ -264,7 +264,7 @@ describe("react-wildcat", () => {
 
                                     return defaultConfig;
                                 },
-                                "./utils/logger": () => {
+                                "./utils/logger": (() => {
                                     function Logger() {}
 
                                     Logger.prototype = {
@@ -275,7 +275,7 @@ describe("react-wildcat", () => {
                                     };
 
                                     return Logger;
-                                }()
+                                })()
                             });
 
                             expect(staticServer)


### PR DESCRIPTION
Updated babel-eslint to 4.1.7 in order to fix build errors when a user runs `make install`