### PR TITLE
Downgraded eslint

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^5.2.0",
     "concurrently": "^1.0.0",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "eslint-config-nfl": "^6.0.1",
     "eslint-import-resolver-jspm": "^1.0.0",
     "eslint-plugin-import": "^0.12.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "codecov.io": "^0.1.6",
     "conventional-changelog": "^0.5.1",
     "cz-conventional-changelog": "^1.1.5",
-    "eslint": "^2.2.0",
+    "eslint": "2.2.0",
     "eslint-config-nfl": "^6.0.1",
     "eslint-import-resolver-jspm": "^1.0.0",
     "eslint-plugin-import": "^0.12.1",


### PR DESCRIPTION
npm install is throwing an error, downgrading eslint prevents it from happening until https://github.com/eslint/eslint/issues/5476 is fixed