### PR TITLE
Custom middleware

### DIFF
--- a/example/api/sampleServerOnlyApi.js
+++ b/example/api/sampleServerOnlyApi.js
@@ -1,0 +1,11 @@
+const route = require("koa-route");
+
+module.exports = function (app, wildcatConfig) {
+    console.log("Initializing server-only api...");
+
+    var sampleRoute = route.get("/react-wildcat-server-only-example", function* () {
+        this.body = "Hello from the server world!";
+    });
+
+    app.use(sampleRoute);
+};

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "version": "1.1.0",
   "dependencies": {
     "babel": "^5.8.29",
+    "koa-route": "^2.4.2",
     "react-wildcat": "1.1.1",
     "rimraf": "^2.5.1"
   },

--- a/example/wildcat.config.js
+++ b/example/wildcat.config.js
@@ -115,6 +115,11 @@ const wildcatConfig = {
             // App server port
             port: getPort(process.env.PORT, 3000),
 
+            middleware: [
+                // EXAMPLE:
+                require("./api/sampleServerOnlyApi")
+            ],
+
             // A key/value of urls to proxy
             // e.g. /static -> http://example.com/static
             proxies: {

--- a/packages/react-wildcat/src/server.js
+++ b/packages/react-wildcat/src/server.js
@@ -107,6 +107,22 @@ function start() {
                 }));
             });
 
+            // Allow custom middleware priority over react/jspm/render from below
+            // otherwise server-only routes will receive 404's.
+            if (appServerSettings.middleware && appServerSettings.middleware.length) {
+                appServerSettings.middleware.forEach(function eachCustomAppMiddleware(middlewareConfigFunction, index) {
+                    if (typeof middlewareConfigFunction === "function") {
+                        middlewareConfigFunction(app, wildcatConfig);
+                    } else {
+                        var errorMsg = `
+Middleware at serverSettings.appServer.middleware[${index}] could not be correclty initialized. Expecting middleware to have the following signature:
+    function(app, wildcatConfig) { /* custom middleware */ }
+    Erroring middleware: ${(middlewareConfigFunction || "").toString()}`;
+                        logger.error(errorMsg, middlewareConfigFunction);
+                    }
+                });
+            }
+
             app.use(renderReactWithJspm(cwd, {
                 logger,
                 wildcatConfig

--- a/packages/react-wildcat/src/utils/templates/wildcat.config.js
+++ b/packages/react-wildcat/src/utils/templates/wildcat.config.js
@@ -115,6 +115,16 @@ const wildcatConfig = {
             // App server port
             port: 3000,
 
+            middleware: [
+                // EXAMPLE: sample server-only api route.
+                //
+                // function(app, wildcatConfig) {
+                //     app.use(route.get("/react-wildcat-server-only-example", function* () {
+                //         this.body = "Hello from the server world!";
+                //     }));
+                // }
+            ],
+
             // A key/value of urls to proxy
             // e.g. /static -> http://example.com/static
             proxies: {},


### PR DESCRIPTION
Thanks to the kick-start feedback in #68, here is an PR in attempt at adding a custom middleware hook for react-wildcat's server side...

### TODO

- [x]  If the `middlewareConfigFunction` call errors, should we try/catch around it and log errors, or just allow exceptions to fail fast. (which will need support from #70 before they are visible).
- [x] Not sure if we should have turned-on the example custom middleware? (Since others may copy/paste the example and run from there without removing the example middleware). Possibly better as documentation?
- [x] I haven't dug into the babel work yet - but so far I'm having to reference a middleware file by calling `src/api/api.js` instead of `public/api/api.js` (so it's not currently running through the babel transformation)
- [x] Add some tests
- [x] Sign CLA

Any suggestions/thoughts?