### PR TITLE
Server performance improvements

### DIFF
--- a/packages/react-wildcat/cli/wildcat.js
+++ b/packages/react-wildcat/cli/wildcat.js
@@ -33,9 +33,5 @@ if (program.purgeCache) {
     process.on("exit", () =>process.emit("SIGINT"));
     process.on("SIGINT", () => killAllChildProcesses("SIGINT"));
 
-    process.on("uncaughtException", e => {
-        logger.error(e.stack);
-        killAllChildProcesses("SIGINT");
-        throw e;
-    });
+    process.on("uncaughtException", e => logger.error(e.stack));
 }

--- a/packages/react-wildcat/cli/wildcatStaticServer.js
+++ b/packages/react-wildcat/cli/wildcatStaticServer.js
@@ -4,6 +4,8 @@ const pkg = require("../package.json");
 const cp = require("child_process");
 const path = require("path");
 const program = require("commander");
+const Logger = require("../src/utils/logger");
+const logger = new Logger("☁️");
 
 const childProcesses = [];
 
@@ -33,7 +35,4 @@ process.on("SIGINT", function () {
     killAllChildProcesses("SIGINT");
 });
 
-process.on("uncaughtException", function (e) {
-    killAllChildProcesses("SIGINT");
-    throw e;
-});
+process.on("uncaughtException", e => logger.error(e.stack));

--- a/packages/react-wildcat/src/staticServer.js
+++ b/packages/react-wildcat/src/staticServer.js
@@ -81,8 +81,6 @@ function start() {
         } else {
             const app = koa();
 
-            app.use(morgan.middleware(":id :status :method :url :res[content-length] - :response-time ms", morganOptions));
-
             // enable cors
             app.use(cors({
                 origin: function origin(ctx) {
@@ -101,6 +99,11 @@ function start() {
                 }
             }));
 
+            // add gzip
+            app.use(compress());
+
+            app.use(morgan.middleware(":id :status :method :url :res[content-length] - :response-time ms", morganOptions));
+
             /* istanbul ignore else */
             if (!__PROD__ || __TEST__) {
                 app.use(babelDevTranspiler(cwd, {
@@ -116,9 +119,6 @@ function start() {
                     sourceDir: serverSettings.sourceDir
                 }));
             }
-
-            // add gzip
-            app.use(compress());
 
             // serve statics
             app.use(fileServer);

--- a/packages/react-wildcat/src/utils/templates/wildcat.config.js
+++ b/packages/react-wildcat/src/utils/templates/wildcat.config.js
@@ -10,6 +10,7 @@ const defaultServerCert = getDefaultSSLFile("server.crt");
 const defaultServerCA = getDefaultSSLFile("server.csr");
 
 const __DEV__ = (process.env.NODE_ENV === "development");
+const __TEST__ = (process.env.NODE_ENV === "test") || (process.env.BABEL_ENV === "test");
 const __PROD__ = (process.env.NODE_ENV === "production");
 
 /* istanbul ignore next */
@@ -90,9 +91,14 @@ const wildcatConfig = {
         // Directory to save raw binaries (jpg, gif, fonts, etc)
         binDir: "bin",
 
+        // Enable the Blue Box of Death to display server errors
+        displayBlueBoxOfDeath: !__PROD__,
+
         hotReload: !__PROD__,
         hotReloader: "react-wildcat-hot-reloader",
         hotReloadReporter: undefined,
+
+        localPackageCache: !__PROD__ || __TEST__,
 
         // BYO-HTML template
         // htmlTemplate: require("./customHTMLTemplate.js"),

--- a/packages/react-wildcat/test/appServerSpec.js
+++ b/packages/react-wildcat/test/appServerSpec.js
@@ -340,6 +340,7 @@ describe("react-wildcat", () => {
                                         },
                                         wildcatConfig: Object.assign({}, wildcatConfig, {
                                             serverSettings: {
+                                                displayBlueBoxOfDeath: (currentEnv !== "production"),
                                                 entry: "stubEntry.js",
                                                 hotReloader: false,
                                                 renderHandler: "stubRenderHandler.js"


### PR DESCRIPTION
Changes:

```
70c20b4
   refactor(react-wildcat): Log uncaught exceptions instead of throwing them

7c723a6
   perf(react-wildcat): Avoid multiple writes to disk when transpiling on the
   server

   Fix a race condition where the static server was writing to disk multiple
   times on concurrent requests. Now the first request to transpile a file
   will save its Promise to cache, and subsequent requests will first check if
   that Promise is available in cache before requesting a transpilation.

1135a6b
   perf(react-wildcat): Load jspm packages from the local file system in
   development mode
```