### PR TITLE
Do not override my config

### DIFF
--- a/packages/react-wildcat/src/utils/getWildcatConfig.js
+++ b/packages/react-wildcat/src/utils/getWildcatConfig.js
@@ -21,7 +21,7 @@ module.exports = function getWildcatConfig(cwd) {
     const staticServerSettings = wildcatConfig.serverSettings.staticServer;
 
     // Add some convenience aliases
-    wildcatConfig = merge(wildcatConfig, {
+    wildcatConfig = merge({
         generalSettings: {
             originUrl: url.format({
                 protocol: appServerSettings.protocol.replace("http2", "https"),
@@ -34,7 +34,7 @@ module.exports = function getWildcatConfig(cwd) {
                 port: staticServerSettings.port
             })
         }
-    });
+    }, wildcatConfig);
 
     return wildcatConfig;
 };

--- a/packages/react-wildcat/test/getWildcatConfigSpec.js
+++ b/packages/react-wildcat/test/getWildcatConfigSpec.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+
+const cwd = process.cwd();
+const path = require("path");
+const proxyquire = require("proxyquire");
+
+/* eslint-disable max-nested-callbacks */
+describe("utils - getWildcatConfig", () => {
+    const exampleDir = path.join(cwd, "example");
+    const projectConfigFile = path.join(exampleDir, "wildcat.config.js");
+
+    before(() => {
+        process.chdir(exampleDir);
+    });
+
+
+    context("when app config HAS specified config values", () => {
+        let wildcatConfig;
+
+        before(() => {
+            var originalConfig = require(projectConfigFile);
+            originalConfig.generalSettings.originUrl = "http://mytestorigin.com";
+            originalConfig.generalSettings.staticUrl = "http://myteststatic.com";
+
+            var mockedRequires = {};
+            mockedRequires[`${exampleDir}/wildcat.config.js`] = () => originalConfig;
+
+            const CustomGetWildcatConfig = proxyquire("../src/utils/getWildcatConfig.js", mockedRequires);
+
+            wildcatConfig = CustomGetWildcatConfig();
+        });
+
+        after(() => {
+            delete wildcatConfig.generalSettings.originUrl;
+            delete wildcatConfig.generalSettings.staticUrl;
+        });
+
+        it("should use specified 'originUrl'", () => {
+            expect(wildcatConfig.generalSettings.originUrl)
+                .to.equal("http://mytestorigin.com");
+        });
+
+        it("should use specified 'staticUrl'", () => {
+            expect(wildcatConfig.generalSettings.staticUrl)
+                .to.equal("http://myteststatic.com");
+        });
+    });
+
+    context("when app config has not specified values", () => {
+        let wildcatConfig;
+
+        before(() => {
+            var originalConfig = require(projectConfigFile);
+            delete originalConfig.generalSettings.originUrl;
+            delete originalConfig.generalSettings.staticUrl;
+
+            var mockedRequires = {};
+            mockedRequires[`${exampleDir}/wildcat.config.js`] = () => originalConfig;
+
+            const CustomGetWildcatConfig = proxyquire("../src/utils/getWildcatConfig.js", mockedRequires);
+
+            wildcatConfig = CustomGetWildcatConfig();
+        });
+
+        it("Should use calculated property 'originUrl'", () => {
+            expect(wildcatConfig.generalSettings.originUrl)
+                .to.equal("https://localhost:3000");
+        });
+
+        it("Should use calculated property 'staticUrl'", () => {
+            expect(wildcatConfig.generalSettings.staticUrl)
+                .to.equal("https://localhost:4000");
+        });
+    });
+});


### PR DESCRIPTION
# TL;DR

`react-wildcat` should never override a value the developer specifies in `wildcat.config.js`.


I have 1 commit here
  - [x] the actual fix (switching the merge ordering) and some tests


# The long version

Trying to work through Heroku deployment. I got to the point where my whole site could be run through a single server.

The last problem was trying to get the template rendered to use my custom domain to render the root template with `http://mysite.herokuapp.com/jspm_packages/system.js`, however this always rendered with `http://localhost:12345/jspm_packages/system.js`. 

I tried updating the `wildcatConfig.serverSettings.staticServer.hostname/port` but each time I touched those values I only ever got `500` responses from heroku (with no error logs that I could find).

After digging in, I found out about the `staticUrl` and `originUrl` values. When I tried to hard-code them in my `wildcat.config.js` that still didn't seem to work. 

Debugging further I found out about the merging of configs happening inside `getWildcatConfig.js` which looked to have the `merge` with the convenience properties `originUrl` & `staticUrl` added on.

I prototyped a hack-fix (without touching wildcat the project) by using the following:


```
var Module             = require('module')
    , originalLoader   = Module._load
Module._load = function(request, parent) {
    if(request && request.indexOf('getWildcatConfig') >= 0) {
        var originalGetWildcatConfig =  originalLoader.apply(this, arguments);
        return function newGetWildcatConfig(cfg) {
            var config = originalGetWildcatConfig(cfg);
            // force-override
            config.generalSettings.originUrl = "http://mysite.herokuapp.com";
            config.generalSettings.staticUrl = "http://mysite.herokuapp.com";
            console.log("re-hacking config");
            console.log(config);
            return config;
        }
    }
    return originalLoader.apply(this, arguments);
};
```

and :boom: I was in business...

So, while I don't know why I couldn't just change the config static `hostname: "localhost"` to `hostname: "mysite.herokuapp.com"`, I still don't think that the framework should be overriding anything I manually stick in the `wildcat.config.js`.

/cc @doctyper 
