### PR TITLE
feat(react-wildcat): Add lifecycle hooks

### DIFF
--- a/packages/react-wildcat/src/server.js
+++ b/packages/react-wildcat/src/server.js
@@ -32,12 +32,17 @@ let server;
 
 function start() {
     const wildcatConfig = require("./utils/getWildcatConfig")(cwd);
+
     const generalSettings = wildcatConfig.generalSettings;
     const serverSettings = wildcatConfig.serverSettings;
 
     const appServerSettings = serverSettings.appServer;
     const secureSettings = appServerSettings.secureSettings;
     const proxySettings = appServerSettings.proxies;
+
+    if (typeof appServerSettings.onBeforeStart === "function") {
+        appServerSettings.onBeforeStart.call(this, wildcatConfig);
+    }
 
     const morganOptions = getMorganOptions(generalSettings.logLevel, serverSettings);
 
@@ -88,6 +93,10 @@ function start() {
             }
 
             const app = koa();
+
+            if (typeof appServerSettings.onStart === "function") {
+                appServerSettings.onStart.call(this, app, wildcatConfig);
+            }
 
             app.use(morgan.middleware(":id :status :method :url :res[content-length] - :response-time ms", morganOptions));
 
@@ -173,6 +182,10 @@ Middleware at serverSettings.appServer.middleware[${index}] could not be correcl
                         logger.ok("Node server is running on pid", process.pid);
                     } else {
                         logger.ok(`Node server is running at ${generalSettings.originUrl} on pid`, process.pid);
+                    }
+
+                    if (typeof appServerSettings.onAfterStart === "function") {
+                        appServerSettings.onAfterStart.call(this, app, wildcatConfig);
                     }
 
                     resolve({

--- a/packages/react-wildcat/src/staticServer.js
+++ b/packages/react-wildcat/src/staticServer.js
@@ -30,11 +30,16 @@ let server;
 
 function start() {
     const wildcatConfig = require("./utils/getWildcatConfig")(cwd);
+
     const generalSettings = wildcatConfig.generalSettings;
     const serverSettings = wildcatConfig.serverSettings;
 
     const staticServerSettings = serverSettings.staticServer;
     const secureSettings = staticServerSettings.secureSettings;
+
+    if (typeof staticServerSettings.onBeforeStart === "function") {
+        staticServerSettings.onBeforeStart.call(this, wildcatConfig);
+    }
 
     const morganOptions = getMorganOptions(generalSettings.logLevel, serverSettings);
 
@@ -92,6 +97,10 @@ function start() {
             });
         } else {
             const app = koa();
+
+            if (typeof staticServerSettings.onStart === "function") {
+                staticServerSettings.onStart.call(this, app, wildcatConfig);
+            }
 
             // enable cors
             app.use(cors({
@@ -187,6 +196,10 @@ function start() {
                         logger.ok("Static server is running");
                     } else {
                         logger.ok(`Static server is running at ${generalSettings.staticUrl}`);
+                    }
+
+                    if (typeof staticServerSettings.onAfterStart === "function") {
+                        staticServerSettings.onAfterStart.call(this, app, wildcatConfig);
                     }
 
                     resolve({

--- a/packages/react-wildcat/src/utils/templates/wildcat.config.js
+++ b/packages/react-wildcat/src/utils/templates/wildcat.config.js
@@ -160,7 +160,16 @@ const wildcatConfig = {
                     "http/1.1",
                     "http/1.0"
                 ]
-            }
+            },
+
+            // onBeforeStart lifecycle is triggered before the application is initialized and before the server starts
+            onBeforeStart: undefined,
+
+            // onStart lifecycle is triggered immediately after the application is initialized but before the server starts
+            onStart: undefined,
+
+            // onAfterStart lifecycle is triggered after the application is initialized and after the server starts
+            onAfterStart: undefined
         },
 
         // config options for the static server
@@ -201,7 +210,16 @@ const wildcatConfig = {
                     "http/1.1",
                     "http/1.0"
                 ]
-            }
+            },
+
+            // onBeforeStart lifecycle is triggered before the application is initialized and before the server starts
+            onBeforeStart: undefined,
+
+            // onStart lifecycle is triggered immediately after the application is initialized but before the server starts
+            onStart: undefined,
+
+            // onAfterStart lifecycle is triggered after the application is initialized and after the server starts
+            onAfterStart: undefined
         }
     }
 };

--- a/packages/react-wildcat/test/appServerSpec.js
+++ b/packages/react-wildcat/test/appServerSpec.js
@@ -767,6 +767,63 @@ describe("react-wildcat", () => {
                 });
             });
         });
+
+        context("lifecycle events", () => {
+            const lifecycleTests = [
+                "onBeforeStart",
+                "onStart",
+                "onAfterStart"
+            ];
+
+            lifecycleTests.forEach(lifecycle => {
+                it(lifecycle, (done) => {
+                    const wildcatConfig = require("../src/utils/getWildcatConfig")();
+                    const appServerSettings = wildcatConfig.serverSettings.appServer;
+                    appServerSettings[lifecycle] = sinon.spy();
+
+                    const server = proxyquire("../src/server.js", {
+                        "cluster": {
+                            isMaster: false,
+                            worker: {
+                                id: 1
+                            }
+                        },
+                        "./utils/getWildcatConfig": () => wildcatConfig,
+                        "./utils/logger": NullConsoleLogger
+                    });
+
+                    expect(server)
+                        .to.exist;
+
+                    expect(server)
+                        .to.respondTo("start");
+
+                    expect(server.start)
+                        .to.be.a("function");
+
+                    server.start()
+                        .then((result) => {
+                            expect(result)
+                                .to.exist;
+
+                            expect(result)
+                                .to.be.an("object")
+                                .that.has.property("env")
+                                .that.equals(process.env.NODE_ENV);
+
+                            expect(appServerSettings[lifecycle].calledOnce)
+                                .to.be.true;
+
+                            server.close();
+                            done();
+                        })
+                        .catch(err => {
+                            server.close();
+                            done(err);
+                        });
+                });
+            });
+        });
     });
 
     after(() => {


### PR DESCRIPTION
Adding onBeforeStart, onStart and onAfterStart lifecycle hooks to both the app and static servers. Useful for bootstrapping functionality before the server runs.