### PR TITLE
fix(react-wildcat): Fix exported paths to binary files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="2.3.0"></a>
+# [2.3.0](https://github.com/nfl/react-wildcat/compare/2.2.0...v2.3.0) (2016-03-24)
+
+
+### Bug Fixes
+
+* **wildcat-babel:** Add option to wait for file write event ([185fe7d](https://github.com/nfl/react-wildcat/commit/185fe7d))
+
+### Features
+
+* **react-wildcat:** Add lifecycle hooks ([59c90d2](https://github.com/nfl/react-wildcat/commit/59c90d2))
+* **wildcat-babel:** Add instrumentation support ([596af69](https://github.com/nfl/react-wildcat/commit/596af69))
+
+
+
 <a name="2.2.0"></a>
 # [2.2.0](https://github.com/nfl/react-wildcat/compare/2.1.1...v2.2.0) (2016-03-22)
 

--- a/example/package.json
+++ b/example/package.json
@@ -1,11 +1,11 @@
 {
   "name": "react-wildcat-example",
   "description": "An example Wildcat project.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "dependencies": {
     "babel": "^5.8.29",
     "koa-route": "^2.4.2",
-    "react-wildcat": "2.2.0",
+    "react-wildcat": "2.3.0",
     "rimraf": "^2.5.1"
   },
   "devDependencies": {

--- a/packages/react-wildcat/cli/utils/copyFiles.js
+++ b/packages/react-wildcat/cli/utils/copyFiles.js
@@ -14,6 +14,7 @@ module.exports = function copyFiles(commander) {
     const wildcatConfig = require("../../src/utils/getWildcatConfig")(cwd);
 
     const serverSettings = wildcatConfig.serverSettings;
+    const generalSettings = wildcatConfig.generalSettings;
     const outDir = commander.outDir || serverSettings.publicDir;
 
     const binaryToModule = commander.binaryToModule;
@@ -38,7 +39,7 @@ module.exports = function copyFiles(commander) {
             relativePath
         };
 
-        const origin = `${wildcatConfig.generalSettings.staticUrl || ""}/`;
+        const origin = generalSettings.staticUrl;
 
         return new Promise((resolveImportable, rejectImportable) => {
             createImportableModule({
@@ -50,7 +51,9 @@ module.exports = function copyFiles(commander) {
                 logLevel: 0,
 
                 temporaryCache: false,
-                binaryToModule
+                binaryToModule,
+
+                root: cwd
             }, resolveImportable, rejectImportable);
         })
             .then(() => done && done())

--- a/packages/react-wildcat/package.json
+++ b/packages/react-wildcat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wildcat",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "An opinionated React environment.",
   "bin": {
     "wildcat": "./cli/wildcat.js",

--- a/packages/react-wildcat/src/middleware/babelDevTranspiler.js
+++ b/packages/react-wildcat/src/middleware/babelDevTranspiler.js
@@ -62,7 +62,9 @@ module.exports = function babelDevTranspiler(root, options) {
                 logLevel,
 
                 temporaryCache,
-                binaryToModule: true
+                binaryToModule: true,
+
+                root
             }, resolve, reject);
         });
 

--- a/packages/react-wildcat/src/utils/createImportableModule.js
+++ b/packages/react-wildcat/src/utils/createImportableModule.js
@@ -9,6 +9,8 @@ module.exports = function createImportableModule(options, resolve, reject) {
     "use strict";
 
     const origin = options.origin;
+    const root = options.root;
+
     const logger = options.logger;
     const logLevel = options.logLevel;
 

--- a/packages/react-wildcat/test/staticServerSpec.js
+++ b/packages/react-wildcat/test/staticServerSpec.js
@@ -73,25 +73,35 @@ describe("react-wildcat", () => {
             const generalSettings = wildcatConfig.generalSettings;
             const serverSettings = wildcatConfig.serverSettings;
 
-            const exampleApplicationPath = `/${serverSettings.publicDir}/components/Application/Application.js`;
-            const exampleApplicationSrcPath = `${serverSettings.sourceDir}/components/Application/Application.js`;
-            const exampleIndexPath = `/${serverSettings.publicDir}/routes/IndexExample/IndexExample.js`;
-            const exampleBinaryPath = `/${serverSettings.publicDir}/assets/images/primary-background.jpg`;
-            const exampleFlexboxPath = `/${serverSettings.publicDir}/routes/FlexboxExample/FlexboxExample.js`;
-            const exampleHelmetPath = `/${serverSettings.publicDir}/routes/HelmetExample/HelmetExample.js`;
-            const exampleNonExistentPath = `/${serverSettings.publicDir}/foo.js`;
+            const binDir = serverSettings.binDir;
+            const publicDir = serverSettings.publicDir;
+            const sourceDir = serverSettings.sourceDir;
+
+            function getBinPath(source) {
+                return source
+                    .replace(publicDir, binDir)
+                    .replace(sourceDir, binDir);
+            }
+
+            const exampleApplicationPath = `/${publicDir}/components/Application/Application.js`;
+            const exampleApplicationSrcPath = `${sourceDir}/components/Application/Application.js`;
+            const exampleIndexPath = `/${publicDir}/routes/IndexExample/IndexExample.js`;
+            const exampleBinaryPath = `/${publicDir}/assets/images/primary-background.jpg`;
+            const exampleFlexboxPath = `/${publicDir}/routes/FlexboxExample/FlexboxExample.js`;
+            const exampleHelmetPath = `/${publicDir}/routes/HelmetExample/HelmetExample.js`;
+            const exampleNonExistentPath = `/${publicDir}/foo.js`;
             const exampleUnaffectedPath = "/foo.js";
 
             const writeDelay = 200;
             const babelDevTranspilerOptions = {
                 babelOptions,
-                binDir: serverSettings.binDir,
+                binDir: binDir,
                 extensions: [".es6", ".js", ".es", ".jsx"],
                 logger: stubLogger,
                 logLevel: 2,
                 origin: generalSettings.staticUrl,
-                outDir: serverSettings.publicDir,
-                sourceDir: serverSettings.sourceDir
+                outDir: publicDir,
+                sourceDir: sourceDir
             };
 
             const coverageOptions = {
@@ -209,11 +219,12 @@ describe("react-wildcat", () => {
                         expect(pathExists.sync(path.join(exampleDir, exampleBinaryPath)))
                             .to.be.true;
 
+                        const origin = generalSettings.staticUrl;
                         const binaryFileContents = fs.readFileSync(path.join(exampleDir, exampleBinaryPath), "utf8");
 
                         expect(binaryFileContents)
                             .to.be.a("string")
-                            .that.matches(/module\.exports = "(.*)";/);
+                            .that.equals(`module.exports = "${origin}${getBinPath(exampleBinaryPath)}";`);
 
                         done();
                     }, writeDelay))
@@ -284,7 +295,7 @@ describe("react-wildcat", () => {
                     .catch(e => done(e));
             });
 
-            it(`ignores a request that does not begin with /${serverSettings.publicDir}`, (done) => {
+            it(`ignores a request that does not begin with /${publicDir}`, (done) => {
                 expect(pathExists.sync(path.join(exampleDir, exampleApplicationPath)))
                     .to.be.true;
 


### PR DESCRIPTION
Fix an issue where importable modules were exporting absolute paths to
binary files. Also adding tests to cover this output.