### PR TITLE
fix(react-wildcat): More absolute paths to modules

### DIFF
--- a/packages/react-wildcat/cli/wildcat.js
+++ b/packages/react-wildcat/cli/wildcat.js
@@ -3,7 +3,8 @@
 const cp = require("child_process");
 const path = require("path");
 const program = require("commander");
-const Logger = require("../src/utils/logger");
+
+const Logger = require(path.resolve(__dirname, "../src/utils/logger"));
 const logger = new Logger("👀");
 
 const pkg = require(path.resolve(__dirname, "../package.json"));

--- a/packages/react-wildcat/cli/wildcatBabel.js
+++ b/packages/react-wildcat/cli/wildcatBabel.js
@@ -5,15 +5,15 @@ const fs = require("fs-extra");
 const cwd = process.cwd();
 const path = require("path");
 
-const pkg = require(path.resolve(__dirname, "../package.json"));
-
 const glob = require("glob");
 const commander = require("commander");
 const chokidar = require("chokidar");
 const resolve = require("resolve");
 
-const Logger = require("../src/utils/logger");
+const Logger = require(path.resolve(__dirname, "../src/utils/logger"));
 const logger = new Logger("🔰");
+
+const pkg = require(path.resolve(__dirname, "../package.json"));
 
 /* istanbul ignore next */
 function patterns(val) {

--- a/packages/react-wildcat/cli/wildcatStaticServer.js
+++ b/packages/react-wildcat/cli/wildcatStaticServer.js
@@ -3,7 +3,8 @@
 const cp = require("child_process");
 const path = require("path");
 const program = require("commander");
-const Logger = require("../src/utils/logger");
+
+const Logger = require(path.resolve(__dirname, "../src/utils/logger"));
 const logger = new Logger("☁️");
 
 const pkg = require(path.resolve(__dirname, "../package.json"));


### PR DESCRIPTION
Make all paths in entry files absolute. Just in case.