### PR TITLE
fix(wildcat-babel): Reimport the logger utility in worker helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ export BABEL_ENV = test
 .PHONY: bootstrap clean install install-example lint publish test test-example test-browser-cov test-cov test-travis update-dependencies
 
 bootstrap:
-	npm install --silent
+	npm install
 	jspm install --log warn -y
 	node ./shell/install.js
-	npm link react-wildcat-prefetch --silent
+	npm link react-wildcat-prefetch
 
 clean:
 	./shell/clean.sh

--- a/example/protractor.config.js
+++ b/example/protractor.config.js
@@ -116,12 +116,6 @@ exports.config = {
     },
 
     plugins: [{
-        package: "protractor-console-plugin",
-        failOnWarning: false,
-        failOnError: false,
-        logWarnings: true,
-        exclude: []
-    }, {
         package: "protractor-istanbul-plugin",
         logAssertions: true,
         failAssertions: true,

--- a/example/src/test/e2e/flows/indexPageFlow.js
+++ b/example/src/test/e2e/flows/indexPageFlow.js
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {expect} from "chai/index.js";
 
 import IndexPageObject from "../objects/IndexPageObject.js";
 import FlexboxPageObject from "../objects/FlexboxPageObject.js";

--- a/example/src/test/e2e/flows/prefetchPageFlow.js
+++ b/example/src/test/e2e/flows/prefetchPageFlow.js
@@ -1,4 +1,4 @@
-import {expect} from "chai";
+import {expect} from "chai/index.js";
 
 import IndexPageObject from "../objects/IndexPageObject.js";
 import FlexboxPageObject from "../objects/FlexboxPageObject.js";

--- a/packages/react-wildcat/cli/test/utils/handleFileSpec.js
+++ b/packages/react-wildcat/cli/test/utils/handleFileSpec.js
@@ -71,7 +71,14 @@ module.exports = (stubs, stubLogger) => {
             const commanderStub = new stubs.CommanderStub(Object.assign({}, stubs.commanderDefaults, {
                 quiet: undefined
             }));
-            const handleFile = require("../../utils/handleFile")(commanderStub, stubs.wildcatOptions);
+            const handleFile = proxyquire("../../utils/handleFile", {
+                [require.resolve("../../../src/utils/logger")]: (() => {
+                    const StubLogger = stubs.Logger;
+                    StubLogger.prototype = stubLogger;
+
+                    return StubLogger;
+                })()
+            })(commanderStub, stubs.wildcatOptions);
 
             handleFile(stubs.exampleBinarySourcePath, (err) => {
                 expect(err)

--- a/packages/react-wildcat/cli/test/wildcatBabelSpec.js
+++ b/packages/react-wildcat/cli/test/wildcatBabelSpec.js
@@ -349,9 +349,9 @@ describe("cli - wildcatBabel", () => {
     });
 
     context("utils", () => {
-        require("./utils/handleSpec")(stubs, loggerStub);
-        require("./utils/handleFileSpec")(stubs, loggerStub);
-        require("./utils/prepImportableModuleSpec")(stubs, loggerStub);
-        require("./utils/prepTranspiledModuleSpec")(stubs, loggerStub);
+        require("./utils/handleSpec.js")(stubs, loggerStub);
+        require("./utils/handleFileSpec.js")(stubs, loggerStub);
+        require("./utils/prepImportableModuleSpec.js")(stubs, loggerStub);
+        require("./utils/prepTranspiledModuleSpec.js")(stubs, loggerStub);
     });
 });

--- a/packages/react-wildcat/cli/utils/handleFile.js
+++ b/packages/react-wildcat/cli/utils/handleFile.js
@@ -1,6 +1,10 @@
 "use strict";
 
+const path = require("path");
 const resolve = require("resolve");
+
+const Logger = require(path.resolve(__dirname, "../../src/utils/logger"));
+const logger = new Logger("🔰");
 
 // Use project babel if found
 let projectBabel;
@@ -31,7 +35,6 @@ module.exports = function handleFile(commander, wildcatOptions) {
     "use strict";
 
     const root = wildcatOptions.root;
-    const logger = wildcatOptions.logger;
 
     const outDir = wildcatOptions.outDir;
     const sourceDir = wildcatOptions.sourceDir;

--- a/packages/react-wildcat/test/appServerSpec.js
+++ b/packages/react-wildcat/test/appServerSpec.js
@@ -29,24 +29,24 @@ describe("appServer", () => {
     });
 
     context("polyfills", () => {
-        require("./polyfills/fetchSpec")();
-        require("./polyfills/baseURISpec")();
+        require("./polyfills/fetchSpec.js")();
+        require("./polyfills/baseURISpec.js")();
     });
 
     context("utils", () => {
-        require("./utils/blueBoxOfDeathSpec")(stubs);
-        require("./utils/customJspmLoaderSpec")(stubs);
-        require("./utils/customMorganTokensSpec")(stubs);
-        require("./utils/getMorganOptionsSpec")(stubs);
-        require("./utils/getWildcatConfigSpec")(stubs);
-        require("./utils/hotReloaderWebSocketSpec")(stubs);
-        require("./utils/logCreateSuccessSpec")(stubs);
-        require("./utils/loggerSpec")(stubs);
-        require("./utils/logTransformErrorSpec")(stubs);
+        require("./utils/blueBoxOfDeathSpec.js")(stubs);
+        require("./utils/customJspmLoaderSpec.js")(stubs);
+        require("./utils/customMorganTokensSpec.js")(stubs);
+        require("./utils/getMorganOptionsSpec.js")(stubs);
+        require("./utils/getWildcatConfigSpec.js")(stubs);
+        require("./utils/hotReloaderWebSocketSpec.js")(stubs);
+        require("./utils/logCreateSuccessSpec.js")(stubs);
+        require("./utils/loggerSpec.js")(stubs);
+        require("./utils/logTransformErrorSpec.js")(stubs);
     });
 
     context("middleware", () => {
-        require("./middleware/renderReactWithJspmSpec")(stubs);
+        require("./middleware/renderReactWithJspmSpec.js")(stubs);
     });
 
     context("app server", () => {

--- a/packages/react-wildcat/test/staticServerSpec.js
+++ b/packages/react-wildcat/test/staticServerSpec.js
@@ -27,13 +27,13 @@ describe("staticServer", () => {
     });
 
     context("utils", () => {
-        require("./utils/createImportableModuleSpec")(stubs);
-        require("./utils/startWebSocketServerSpec")(stubs);
-        require("./utils/createTranspiledModuleSpec")(stubs);
+        require("./utils/createImportableModuleSpec.js")(stubs);
+        require("./utils/startWebSocketServerSpec.js")(stubs);
+        require("./utils/createTranspiledModuleSpec.js")(stubs);
     });
 
     context("middleware", () => {
-        require("./middleware/babelDevTranspilerSpec")(stubs);
+        require("./middleware/babelDevTranspilerSpec.js")(stubs);
     });
 
     context("static server", () => {

--- a/shell/install-example.js
+++ b/shell/install-example.js
@@ -18,7 +18,6 @@ exec(`jspm install --log warn -y`);
 cd(cwd);
 
 ls("packages/*").forEach((loc) => {
-    const name = path.basename(loc);
     const pkgPath = path.join(cwd, loc, "package.json");
 
     if (!fs.existsSync(pkgPath)) {
@@ -30,12 +29,12 @@ ls("packages/*").forEach((loc) => {
     cd(example);
 
     // Link package to npm
-    exec(`npm link`);
+    exec(`npm link ${pkg.name}`);
 
-    if (name !== "react-wildcat" && name !== "react-wildcat-test-runners") {
+    if (pkg.name !== "react-wildcat" && pkg.name !== "react-wildcat-test-runners") {
         // Link package to jspm
-        console.log(`jspm install --link npm:${name}@${pkg.version} --log warn -y`);
-        exec(`jspm install --link npm:${name}@${pkg.version} --log warn -y`);
+        console.log(`jspm install --link npm:${pkg.name}@${pkg.version} --log warn -y`);
+        exec(`jspm install --link npm:${pkg.name}@${pkg.version} --log warn -y`);
     }
 
     cd(cwd);


### PR DESCRIPTION
Fixes an issue where the logger functions were being lost when running this function in a worker
process.