### PR TITLE
fix(react-wildcat-prefetch): Wrap composed component display name to avoid losing its canonical name

### DIFF
--- a/packages/react-wildcat-prefetch/src/index.js
+++ b/packages/react-wildcat-prefetch/src/index.js
@@ -44,6 +44,10 @@ function invariantCheck(exists, key, action, ComposedComponent) {
     );
 }
 
+function getDisplayName(Comp) {
+    return Comp.displayName || Comp.name || "Component";
+}
+
 /**
  *
  * @param {React.Component} Component
@@ -132,6 +136,7 @@ function prefetch(action, options) {
         };
 
         Prefetch.WrappedComponent = ComposedComponent;
+        Prefetch.displayName = "Prefetch(" + getDisplayName(ComposedComponent) + ")";
 
         return hoistStatics(Prefetch, ComposedComponent);
     };


### PR DESCRIPTION
This will help code debugging by wrapping the original component's display name instead of overwriting it.