### PR TITLE
chore(react-wildcat): Remove koa-favicon

### DIFF
--- a/packages/react-wildcat/package.json
+++ b/packages/react-wildcat/package.json
@@ -26,7 +26,6 @@
     "koa-conditional-get": "^1.0.3",
     "koa-cors": "0.0.16",
     "koa-etag": "^2.1.1",
-    "koa-favicon": "^1.2.1",
     "koa-file-server": "nfl/file-server#feature/optional-gzip",
     "koa-morgan": "^0.4.0",
     "koa-proxy": "^0.5.0",

--- a/packages/react-wildcat/src/server.js
+++ b/packages/react-wildcat/src/server.js
@@ -7,12 +7,10 @@ const koa = require("koa");
 const cors = require("koa-cors");
 const etag = require("koa-etag");
 const proxy = require("koa-proxy");
-const favicon = require("koa-favicon");
 const compress = require("koa-compress");
 const conditional = require("koa-conditional-get");
 
 const cwd = process.cwd();
-const path = require("path");
 
 const http = require("http");
 const http2 = require("spdy");
@@ -104,9 +102,6 @@ function start() {
 
             // add gzip
             app.use(compress());
-
-            // Handle the pesky favicon
-            app.use(favicon(path.join(cwd, "favicon.ico")));
 
             Object.keys(proxySettings).forEach(function eachProxyRoute(proxyRoute) {
                 const host = proxySettings[proxyRoute];

--- a/packages/react-wildcat/src/utils/blueBoxOfDeath.js
+++ b/packages/react-wildcat/src/utils/blueBoxOfDeath.js
@@ -13,7 +13,7 @@ module.exports = function blueBoxOfDeath(err, request) {
 <html>
     <head>
         <title>‼️💩️️ Runtime Error️</title>
-        <meta name="viewport" content="width=device-width; initial-scale=1.0;">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <style>
             .bbod, .bbod * {
                 margin: 0;


### PR DESCRIPTION
Remove koa-favicon, users can now define their own custom middleware for minor fixes like this.