### PR TITLE
feat(react-wildcat-prefetch): Make decorator arguments optional

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -29,6 +29,7 @@ module.exports = function (karmaConfig) {
 
         client: {
             mocha: {
+                bail: true,
                 reporter: "html",
                 slow: timeout / 2,
                 timeout

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -68,7 +68,10 @@ module.exports = function serverRender(cfg) {
                             data: initialData,
                             head: head,
                             html: reactMarkup,
-                            wildcatConfig
+                            wildcatConfig,
+                            request,
+                            cookies,
+                            renderProps
                         });
 
                         result = Object.assign({}, result, {

--- a/packages/react-wildcat-prefetch/package.json
+++ b/packages/react-wildcat-prefetch/package.json
@@ -13,6 +13,11 @@
     "babel": "^5.8.29",
     "rimraf": "^2.5.2"
   },
+  "jspm": {
+    "directories": {
+      "lib": "dist"
+    }
+  },
   "scripts": {
     "build": "npm run clean && npm run compile",
     "clean": "rimraf dist",

--- a/packages/react-wildcat-prefetch/src/index.js
+++ b/packages/react-wildcat-prefetch/src/index.js
@@ -13,6 +13,10 @@ function getAction(action, ComposedComponent) {
             return action;
 
         case "string":
+            if (ComposedComponent.hasOwnProperty(action)) {
+                return ComposedComponent[action];
+            }
+
             return function asyncAction() {
                 return new Promise(function asyncPromise(resolve) {
                     return fetch(action)

--- a/packages/react-wildcat-prefetch/src/index.js
+++ b/packages/react-wildcat-prefetch/src/index.js
@@ -65,13 +65,13 @@ function getDisplayName(Comp) {
  * If action is a function it will execute the function
  * If action is an string it will make a request based on that url
  */
-function prefetch(action, options) {
+function prefetchWrap(action, options) {
     var key;
 
     options = options || {};
     key = options.key || (typeof options === "string" ? options : __DEFAULT_KEY__);
 
-    return function wrap(ComposedComponent) {
+    return function prefetchWrapper(ComposedComponent) {
         action = action || ComposedComponent[__DEFAULT_STATIC_METHOD__];
         var _action = getAction(action, ComposedComponent);
 
@@ -148,4 +148,10 @@ function prefetch(action, options) {
     };
 }
 
-module.exports = prefetch;
+module.exports = function prefetch(target, ...args) {
+    if (typeof target === "function" && typeof target.displayName === "string") {
+        return prefetchWrap()(target, ...args);
+    }
+
+    return prefetchWrap(target, ...args);
+};

--- a/packages/react-wildcat-prefetch/src/index.js
+++ b/packages/react-wildcat-prefetch/src/index.js
@@ -5,6 +5,7 @@ import hoistStatics from "hoist-non-react-statics";
 
 const __INITIAL_DATA__ = "__INITIAL_DATA__";
 const __DEFAULT_KEY__ = "asyncData";
+const __DEFAULT_STATIC_METHOD__ = "fetchData";
 
 function getAction(action, ComposedComponent) {
     switch (typeof action) {
@@ -67,6 +68,7 @@ function prefetch(action, options) {
     key = options.key || (typeof options === "string" ? options : __DEFAULT_KEY__);
 
     return function wrap(ComposedComponent) {
+        action = action || ComposedComponent[__DEFAULT_STATIC_METHOD__];
         var _action = getAction(action, ComposedComponent);
 
         var Prefetch = React.createClass({

--- a/packages/react-wildcat-prefetch/src/test/browser/fixtures/CustomPrefetchStatic.js
+++ b/packages/react-wildcat-prefetch/src/test/browser/fixtures/CustomPrefetchStatic.js
@@ -1,0 +1,13 @@
+import React from "react";
+
+class CustomPrefetchStatic extends React.Component {
+    static customFetchData() {
+        return Promise.resolve(42);
+    }
+
+    render() {
+        return <div>{Object.keys(this.props)}</div>;
+    }
+}
+
+export default CustomPrefetchStatic;

--- a/packages/react-wildcat-prefetch/src/test/browser/fixtures/DefaultPrefetchStatic.js
+++ b/packages/react-wildcat-prefetch/src/test/browser/fixtures/DefaultPrefetchStatic.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+class DefaultPrefetchStatic extends React.Component {
+    static displayName = "DefaultPrefetchStatic";
+
+    static fetchData() {
+        return Promise.resolve(42);
+    }
+
+    render() {
+        return <div>{Object.keys(this.props)}</div>;
+    }
+}
+
+export default DefaultPrefetchStatic;

--- a/packages/react-wildcat-prefetch/src/test/browser/fixtures/stubData.js
+++ b/packages/react-wildcat-prefetch/src/test/browser/fixtures/stubData.js
@@ -38,6 +38,7 @@ export const prefetchedDataCustomKey = {
 
 export const prefetchUrl = "https://example.com/example.json";
 export const prefetchInvalidUrl = "https://example.com/invalid.json";
+export const customFetchDataResponse = 42;
 
 export const fetchPromise = () => Promise.resolve(prefetchedData.asyncData);
 export const firstFetchPromise = () => Promise.resolve(prefetchedData.firstData);

--- a/packages/react-wildcat-prefetch/src/test/browser/prefetchSpec.js
+++ b/packages/react-wildcat-prefetch/src/test/browser/prefetchSpec.js
@@ -5,6 +5,8 @@ import Prefetch from "../../index.js"; // eslint-disable-line import/default
 import Hello from "./fixtures/Hello.js";
 import HelloES7 from "./fixtures/HelloES7.js";
 import World from "./fixtures/World.js";
+import CustomPrefetchStatic from "./fixtures/CustomPrefetchStatic.js";
+import DefaultPrefetchStatic from "./fixtures/DefaultPrefetchStatic.js";
 
 import * as stubs from "./fixtures/stubData.js";
 
@@ -170,6 +172,50 @@ describe("react-wildcat-prefetch", () => {
                         expect(response)
                             .to.be.an("object")
                             .that.has.keys(stubs.prefetchedData.asyncData);
+
+                        done();
+                    });
+
+                expect(runner)
+                    .to.be.an.instanceof(Promise);
+            });
+
+            it("fetches data from a custom static method", (done) => {
+                WrappedPrefetch = Prefetch("customFetchData")(CustomPrefetchStatic);
+
+                expect(WrappedPrefetch.prefetch)
+                    .to.exist;
+
+                expect(WrappedPrefetch.prefetch)
+                    .to.respondTo("run");
+
+                const runner = WrappedPrefetch.prefetch.run()
+                    .then((response) => {
+                        expect(response)
+                            .to.be.a("number")
+                            .that.equals(stubs.customFetchDataResponse);
+
+                        done();
+                    });
+
+                expect(runner)
+                    .to.be.an.instanceof(Promise);
+            });
+
+            it("fetches data from default static method", (done) => {
+                WrappedPrefetch = Prefetch(DefaultPrefetchStatic);
+
+                expect(WrappedPrefetch.prefetch)
+                    .to.exist;
+
+                expect(WrappedPrefetch.prefetch)
+                    .to.respondTo("run");
+
+                const runner = WrappedPrefetch.prefetch.run()
+                    .then((response) => {
+                        expect(response)
+                            .to.be.a("number")
+                            .that.equals(stubs.customFetchDataResponse);
 
                         done();
                     });


### PR DESCRIPTION
Allow @prefetch to be invoked without arguments. Given a React component that assumes default values, it can now be wrapped with an arg-less decorator:

```js
@prefetch
class Foo extends React.Component {
    // Prefetch assumes fetchData as the default prefetch handler
    static fetchData() {
        return Promise.resolve(42);
    }

    render() {
        // this.props.asyncData will be populated with data from Foo.fetchData
        const {asyncData} = this.props;
        return <div>{asyncData}</div>; // Prints <div>42</div>
    }
}
```