### PR TITLE
fix(react-wildcat): Limit to one worker per server in dev mode

### DIFF
--- a/packages/react-wildcat/src/server.js
+++ b/packages/react-wildcat/src/server.js
@@ -58,10 +58,10 @@ function start() {
 
     if (!__PROD__ || __TEST__) {
         https.globalAgent.options.rejectUnauthorized = false;
-    }
 
-    if (__TEST__ && !wildcatConfig.__ClusterServerTest__) {
-        cpuCount = 1;
+        if (!wildcatConfig.__ClusterServerTest__) {
+            cpuCount = appServerSettings.minClusterCpuCount;
+        }
     }
 
     const port = Number(appServerSettings.port);

--- a/packages/react-wildcat/src/staticServer.js
+++ b/packages/react-wildcat/src/staticServer.js
@@ -66,12 +66,11 @@ function start() {
         }
 
         https.globalAgent.options.rejectUnauthorized = false;
-    }
 
-    if (__TEST__ && !wildcatConfig.__ClusterServerTest__) {
-        cpuCount = 1;
+        if (!wildcatConfig.__ClusterServerTest__) {
+            cpuCount = staticServerSettings.minClusterCpuCount;
+        }
     }
-
     const port = Number(staticServerSettings.port);
 
     const allowedOrigins = (staticServerSettings.corsOrigins).concat([staticServerSettings.host]);

--- a/packages/react-wildcat/src/utils/templates/wildcat.config.js
+++ b/packages/react-wildcat/src/utils/templates/wildcat.config.js
@@ -125,6 +125,10 @@ const wildcatConfig = {
             // App server port
             port: 3000,
 
+            // number to limit the min number of CPU's
+            // to spin up on a cluster
+            minClusterCpuCount: 1,
+
             // number to limit the max number of CPU's
             // to spin up on a cluster
             maxClusterCpuCount: Infinity, // Infinity === as many CPU's as the machine has
@@ -188,6 +192,10 @@ const wildcatConfig = {
 
             // Static server port
             port: 4000,
+
+            // number to limit the min number of CPU's
+            // to spin up on a cluster
+            minClusterCpuCount: 1,
 
             // number to limit the max number of CPU's
             // to spin up on a cluster


### PR DESCRIPTION
By default, only start one process per server in non-production mode. This value is configurable.