### PR TITLE
feat(react-wildcat-handoff): Add configurable server render type

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "co": "^4.6.0",
     "codecov.io": "^0.1.6",
     "conventional-changelog-cli": "^1.1.1",
-    "cz-conventional-changelog": "^1.1.5",
+    "cz-conventional-changelog": "1.1.5",
     "eslint": "^2.8.0",
     "eslint-config-nfl": "^7.0.1",
     "eslint-import-resolver-jspm": "^2.1.0",

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -52,7 +52,17 @@ module.exports = function serverRender(cfg) {
                         })
                 )
                     .then(function serverRenderPromiseResult() {
-                        const reactMarkup = ReactDOM.renderToString(
+                        const renderType = wildcatConfig.serverSettings.renderType;
+
+                        const getRenderType = (typeof renderType === "function") ?
+                            renderType({
+                                wildcatConfig,
+                                request,
+                                cookies,
+                                renderProps
+                            }) : renderType;
+
+                        const reactMarkup = ReactDOM[getRenderType](
                             serverContext(request, cookies, renderProps)
                         );
 

--- a/packages/react-wildcat-handoff/test/serverHandoffSpec.js
+++ b/packages/react-wildcat-handoff/test/serverHandoffSpec.js
@@ -136,6 +136,29 @@ describe("react-wildcat-handoff/server", () => {
                     .to.be.an.instanceof(Promise);
             });
 
+            it("returns HTML as statid markup", (done) => {
+                const serverHandoff = server(stubs.routes);
+
+                expect(serverHandoff)
+                    .to.be.a("function")
+                    .that.has.property("name")
+                    .that.equals("serverHandoff");
+
+                const result = serverHandoff(stubs.requests.basic, stubs.cookieParser, stubs.wildcatConfigRenderType)
+                    .then(response => {
+                        expect(response)
+                            .to.be.an("object")
+                            .that.has.property("html")
+                            .that.is.a("string");
+
+                        done();
+                    })
+                    .catch(error => done(error));
+
+                expect(result)
+                    .to.be.an.instanceof(Promise);
+            });
+
             it("adds a WebSocket listener on the client in development mode", (done) => {
                 const existingEnv = process.env.NODE_ENV;
                 process.env.NODE_ENV = "development";

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -109,9 +109,18 @@ exports.wildcatConfig = {
     },
     serverSettings: {
         hotReload: true,
-        hotReloader: "react-wildcat-hot-reloader"
+        hotReloader: "react-wildcat-hot-reloader",
+        renderType: "renderToString"
     }
 };
+
+exports.wildcatConfigRenderType = Object.assign({}, exports.wildcatConfig, {
+    serverSettings: {
+        hotReload: true,
+        hotReloader: "react-wildcat-hot-reloader",
+        renderType: () => "renderToStaticMarkup"
+    }
+});
 
 exports.Application = React.createClass({
     displayName: "Application",

--- a/packages/react-wildcat/src/utils/templates/wildcat.config.js
+++ b/packages/react-wildcat/src/utils/templates/wildcat.config.js
@@ -113,6 +113,9 @@ const wildcatConfig = {
         // Path to your source JavaScript files
         sourceDir: "src",
 
+        // One of "renderToString" | "renderToStaticMarkup" | a function that returns either of the two strings
+        renderType: "renderToString",
+
         // config options for the app server
         appServer: {
             // One of "http2" | "https" | "http"


### PR DESCRIPTION
Add a configuration to use renderToString vs renderToStaticMarkup