### PR TITLE
perf(example): Move React into separate bundle.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -106,7 +106,9 @@
   },
   "scripts": {
     "build": "npm run compile -- --ignore '**/{shell,e2e,test}/**' --minify && npm run bundle",
-    "bundle": "jspm bundle 'react-wildcat-handoff/client + (public/**/* - [public/**/*])' bundles/vendor.js --inject --minify --skip-source-maps",
+    "bundle": "npm run bundle-react && npm run bundle-vendors",
+    "bundle-react": "jspm bundle 'react + react-dom' bundles/react.js --minify --skip-source-maps",
+    "bundle-vendors": "jspm bundle 'react-wildcat-handoff/client + (public/**/* - [public/**/*]) - (react + react-dom)' bundles/vendor.js --inject --minify --skip-source-maps",
     "clean": "rimraf bin bundles public",
     "compile": "wildcat-babel --copy-files --binary-to-module src --out-dir public",
     "compile:unit": "env BABEL_ENV=test NODE_ENV=production npm run compile -- --ignore '**/!(*Test).*'",

--- a/example/system.config.js
+++ b/example/system.config.js
@@ -262,8 +262,7 @@ System.config({
     },
     "npm:brace-expansion@1.1.4": {
       "balanced-match": "npm:balanced-match@0.4.1",
-      "concat-map": "npm:concat-map@0.0.1",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
+      "concat-map": "npm:concat-map@0.0.1"
     },
     "npm:browserify-aes@1.0.6": {
       "buffer": "github:jspm/nodelibs-buffer@0.1.0",
@@ -902,8 +901,7 @@ System.config({
       "pinkie": "npm:pinkie@2.0.4"
     },
     "npm:process-nextick-args@1.0.7": {
-      "process": "github:jspm/nodelibs-process@0.1.2",
-      "systemjs-json": "github:systemjs/plugin-json@0.1.2"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:process@0.11.3": {
       "assert": "github:jspm/nodelibs-assert@0.1.0"

--- a/packages/react-wildcat-handoff/src/utils/defaultTemplate.js
+++ b/packages/react-wildcat-handoff/src/utils/defaultTemplate.js
@@ -32,8 +32,11 @@ module.exports = function defaultTemplate(cfg) {
     <head>
         <link rel="dns-prefetch" href="${staticUrl}" />
         <link rel="preconnect" href="${staticUrl}" />
+
         <link rel="prefetch" href="${staticUrl}/jspm_packages/system.js" />
         <link rel="prefetch" href="${staticUrl}/system.config.js" />
+        <link rel="prefetch" href="${staticUrl}/bundles/react.js" />
+
         ${helmetTags.join(``)}
     </head>
     <body>
@@ -162,6 +165,7 @@ module.exports = function defaultTemplate(cfg) {
         </script>
 
         <script src="${staticUrl}/system.config.js"></script>
+        ${__PROD__ ? `<script src="${staticUrl}/bundles/react.js"></script>` : ``}
 
         <script>
             Promise.all([


### PR DESCRIPTION
Sharding vendors across multiple files. Improves bootstrap performance over 3G speeds.