### PR TITLE
fix(react-wildcat-handoff): Add development-specific TLDs

### DIFF
--- a/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
+++ b/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
@@ -12,7 +12,14 @@ function getDomainDataFromHost(host) {
         "local": defaultSubdomain
     };
 
-    var url = parseDomain(host) || {
+    var url = parseDomain(host, {
+        customTlds: [
+            "example",
+            "invalid",
+            "localhost",
+            "test"
+        ]
+    }) || {
         domain: (host || "").split(":")[0],
         subdomain: defaultSubdomain,
         tld: undefined

--- a/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
+++ b/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
@@ -13,6 +13,7 @@ function getDomainDataFromHost(host) {
     };
 
     var url = parseDomain(host, {
+        // https://iyware.com/dont-use-dev-for-development/
         customTlds: [
             "example",
             "invalid",


### PR DESCRIPTION
Add development-specific TLDs following this guide: https://iyware.com/dont-use-dev-for-development/
/cc @potench