### PR TITLE
feat(react-wildcat-handoff): Add support for domain aliases

### DIFF
--- a/packages/react-wildcat-handoff/test/serverHandoffSpec.js
+++ b/packages/react-wildcat-handoff/test/serverHandoffSpec.js
@@ -380,6 +380,33 @@ describe("react-wildcat-handoff/server", () => {
             });
         });
 
+        context("matches domain aliases", () => {
+            ["async", "sync"].forEach((timing) => {
+                it(timing, (done) => {
+                    const serverHandoff = server(stubs.domains[timing]);
+
+                    expect(serverHandoff)
+                        .to.be.a("function")
+                        .that.has.property("name")
+                        .that.equals("serverHandoff");
+
+                    const result = serverHandoff(stubs.requests.ip, stubs.cookieParser, stubs.wildcatConfig)
+                        .then(response => {
+                            expect(response)
+                                .to.be.an("object")
+                                .that.has.property("html")
+                                .that.is.a("string");
+
+                            done();
+                        })
+                        .catch(error => done(error));
+
+                    expect(result)
+                        .to.be.an.instanceof(Promise);
+                });
+            });
+        });
+
         it("handles matching errors", (done) => {
             const serverHandoff = server(stubs.invalidDomains.async);
 

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -49,6 +49,14 @@ exports.requests = {
         url: "/"
     },
 
+    ip: {
+        header: {
+            host: "127.0.0.1",
+            "user-agent": exports.stubUserAgent
+        },
+        url: "/"
+    },
+
     noSubdomain: {
         header: {
             host: "example.com",
@@ -256,14 +264,19 @@ exports.unwrappedSubdomains = {
     }
 };
 
+exports.domainAliases = {
+    "example": [
+        "127.0.0.1",
+        "localhost"
+    ]
+};
+
 exports.domains = {
     async: {
         domains: {
-            example: function getExampleRoutes(location, cb) {
-                return setTimeout(() => cb(null, exports.subdomains.async), 0);
-            },
+            domainAliases: exports.domainAliases,
 
-            localhost: function getLocalhostRoutes(location, cb) {
+            example: function getExampleRoutes(location, cb) {
                 return setTimeout(() => cb(null, exports.subdomains.async), 0);
             }
         }
@@ -271,8 +284,8 @@ exports.domains = {
 
     sync: {
         domains: {
-            example: exports.subdomains.sync,
-            localhost: exports.subdomains.sync
+            domainAliases: exports.domainAliases,
+            example: exports.subdomains.sync
         }
     }
 };
@@ -280,6 +293,8 @@ exports.domains = {
 exports.unwrappedDomains = {
     async: {
         domains: {
+            domainAliases: exports.domainAliases,
+
             example: function getUnwrappedExampleRoutes(location, cb) {
                 return setTimeout(() => cb(null, exports.unwrappedSubdomains.async), 0);
             },
@@ -292,6 +307,8 @@ exports.unwrappedDomains = {
 
     sync: {
         domains: {
+            domainAliases: exports.domainAliases,
+
             example: exports.unwrappedSubdomains.sync,
             localhost: exports.unwrappedSubdomains.sync
         }
@@ -301,6 +318,8 @@ exports.unwrappedDomains = {
 exports.invalidDomains = {
     async: {
         domains: {
+            domainAliases: exports.domainAliases,
+
             example: function getInvalidExampleRoutes(location, cb) {
                 return setTimeout(() => cb(exports.callbackError, null), 0);
             },


### PR DESCRIPTION
This PR adds support for domain aliases when using domain matching. It works by defining a `domainAliases` config in your domain config:

```js
{
    domainAliases: {
        example: [
            localhost // Navigating to https://localhost:3000 will now match the example domain
        ]
    },
    example: {
        www: {} // ...etc
    }
}
```