### PR TITLE
fix(react-wildcat-handoff): Replace arrow functions with named callbacks.

### DIFF
--- a/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
+++ b/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
@@ -11,10 +11,10 @@ function mapDomainToAlias(host, domainAliases) {
 
     if (typeof domainAliases === "object") {
         Object.keys(domainAliases)
-            .forEach(alias => {
+            .forEach(function withAlias(alias) {
                 var possibleHosts = domainAliases[alias];
 
-                possibleHosts.forEach(possibleHost => {
+                possibleHosts.forEach(function withPossibleHost(possibleHost) {
                     if (host.startsWith(possibleHost)) {
                         resolvedHost = alias;
                     }


### PR DESCRIPTION
De-ES6-ify the client bundle.