### PR TITLE
fix(react-wildcat-handoff): Add dev to customTlds

### DIFF
--- a/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
+++ b/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
@@ -64,8 +64,8 @@ function getDomainDataFromHost(host, domains) {
     var resolvedSubdomain = mapSubdomainToAlias(host, domains.domainAliases);
 
     var url = parseDomain(host, {
-        // https://iyware.com/dont-use-dev-for-development/
         customTlds: [
+            "dev",
             "example",
             "invalid",
             "localhost",

--- a/packages/react-wildcat-handoff/webpack.config.js
+++ b/packages/react-wildcat-handoff/webpack.config.js
@@ -12,7 +12,5 @@ module.exports = {
         library: "react-wildcat-handoff",
         libraryTarget: "commonjs2"
     },
-    externals: [nodeExternals({
-        whitelist: ["parse-domain"]
-    })]
+    externals: [nodeExternals()]
 };


### PR DESCRIPTION
Adding `.dev` to customTlds and remove `parse-domain` from generated Webpack bundle.