### PR TITLE
build(wildcat): Specify a single code coverage file

### DIFF
--- a/shell/combine-coverage.sh
+++ b/shell/combine-coverage.sh
@@ -9,7 +9,7 @@ node ${istanbulBin} report lcov
 
 if [ -n "$CI" ]; then
     # Send to codecov.io
-    cat ./coverage/lcov.info | ./node_modules/.bin/codecov
+    ./node_modules/.bin/codecov -f ./coverage/lcov.info
 else
     # Open in browser
     test -n "`which open`" && open coverage/lcov-report/index.html


### PR DESCRIPTION
The original command was uploading both the lcov.info and coverage.json file. We only want lcov.info uploaded