### PR TITLE
fix(react-wildcat-handoff): Handle subdomain aliases in getDomainRoutes

### DIFF
--- a/packages/react-wildcat-handoff/package.json
+++ b/packages/react-wildcat-handoff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wildcat-handoff",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Default client/server rendering for react-wildcat",
   "dependencies": {
     "cookie": "^0.3.1",

--- a/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
+++ b/packages/react-wildcat-handoff/src/utils/getDomainRoutes.js
@@ -71,8 +71,8 @@ function mapSubdomainToAlias(host, domainAliases) {
         var subdomainAliases = {
             "local": defaultSubdomain
         };
-        var result = subdomainAliases[subdomain] || defaultSubdomain;
-        return result;
+
+        return subdomainAliases[subdomain] || subdomain || defaultSubdomain;
     }
 
     return getLeadingLeafDomain(resolvedHost) || defaultSubdomain;
@@ -80,7 +80,6 @@ function mapSubdomainToAlias(host, domainAliases) {
 
 function getDomainDataFromHost(host, domains) {
     var hostExcludingPort = (host || "").split(":")[0];
-    var resolvedSubdomain = mapSubdomainToAlias(host, domains.domainAliases);
 
     var url = parseDomain(host, {
         customTlds: [
@@ -92,13 +91,17 @@ function getDomainDataFromHost(host, domains) {
         ]
     }) || {
         domain: hostExcludingPort,
-        subdomain: resolvedSubdomain,
+        subdomain: undefined,
         tld: undefined
     };
 
     var resolvedDomain = mapDomainToAlias(url.domain, domains.domainAliases);
-    url.domain = resolvedDomain;
-    url.subdomain = url.subdomain.length ? url.subdomain : defaultSubdomain;
+    var resolvedSubdomain = url.subdomain ? mapSubdomainToAlias(host, domains.domainAliases) : null;
+
+    url = Object.assign({}, url, {
+        domain: resolvedDomain,
+        subdomain: resolvedSubdomain || url.subdomain || defaultSubdomain
+    });
 
     return url;
 }

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -341,6 +341,7 @@ exports.domainAliases = {
     "example": {
         "www": [
             "localhost",
+            "example",
             "www.example",
             "127.0.0.1"
         ],

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -341,7 +341,7 @@ exports.domainAliases = {
     "example": {
         "www": [
             "localhost",
-            "example",
+            "www.example",
             "127.0.0.1"
         ],
         "dev": "127.0.0.2"


### PR DESCRIPTION
Fixes a bug to allow `x.example.com` to alias to `y.anotherdomain.com`