### PR TITLE
Feature: Custom 404 Error template support

### DIFF
--- a/example/wildcat.config.js
+++ b/example/wildcat.config.js
@@ -95,6 +95,9 @@ const wildcatConfig = {
         // BYO-HTML template
         // htmlTemplate: require("./customHtmlTemplate.js"),
 
+        // BYO-HTML 404 template
+        // htmlNotFoundTemplate: require("./customHtmlNotFoundTemplate.js"),
+
         // Graylog config options for the node server
         // https://www.npmjs.com/package/gelf-pro#configuration
         // graylog: {},

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -136,10 +136,9 @@ function getHtmlNotFoundTemplate(serverSettings) {
             status: 404,
             html: htmlNotFoundTemplate
         };
-    } else {
-        return {
-            error: 'Not found',
-            status: 404
-        };
     }
+    return {
+        error: "Not found",
+        status: 404
+    };
 }

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -33,10 +33,7 @@ module.exports = function serverRender(cfg) {
                     status: 301
                 };
             } else if (!renderProps) {
-                result = {
-                    error: "Not found",
-                    status: 404
-                };
+                result = getHtmlNotFoundTemplate(wildcatConfig.serverSettings);
             } else {
                 let initialData = null;
 
@@ -131,3 +128,18 @@ module.exports = function serverRender(cfg) {
         });
     });
 };
+
+function getHtmlNotFoundTemplate(serverSettings) {
+    const {htmlNotFoundTemplate} = serverSettings;
+    if (htmlNotFoundTemplate) {
+        return {
+            status: 404,
+            html: htmlNotFoundTemplate
+        };
+    } else {
+        return {
+            error: 'Not found',
+            status: 404
+        };
+    }
+}

--- a/packages/react-wildcat-handoff/test/serverHandoffSpec.js
+++ b/packages/react-wildcat-handoff/test/serverHandoffSpec.js
@@ -86,6 +86,34 @@ describe("react-wildcat-handoff/server", () => {
                 .to.be.an.instanceof(Promise);
         });
 
+        it("returns custom 404 when a route is not found", (done) => {
+            const serverHandoff = server(stubs.routes.sync);
+
+            expect(serverHandoff)
+                .to.be.a("function")
+                .that.has.property("name")
+                .that.equals("serverHandoff");
+
+            const result = serverHandoff(stubs.requests.invalid, stubs.cookieParser, stubs.wildcatConfigWithHtmlNotFoundTemplate)
+                .then(response => {
+                    expect(response)
+                        .to.be.an("object")
+                        .that.has.property("html")
+                        .that.equals("<html><h1>Custom 404 Template</h1></html>");
+
+                    expect(response)
+                        .to.be.an("object")
+                        .that.has.property("status")
+                        .that.equals(404);
+
+                    done();
+                })
+                .catch(error => done(error));
+
+            expect(result)
+                .to.be.an.instanceof(Promise);
+        });
+
         it("returns 404 with an undefined ip address alias", (done) => {
             const serverHandoff = server(stubs.domains.domainAliasesUndefined);
 

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -227,6 +227,18 @@ exports.wildcatConfigRenderType = Object.assign({}, exports.wildcatConfig, {
     }
 });
 
+exports.wildcatConfigWithHtmlNotFoundTemplate = Object.assign({}, exports.wildcatConfig, {
+    serverSettings: {
+        hotReload: true,
+        hotReloader: "react-wildcat-hot-reloader",
+        renderType: "renderToString",
+        appServer: {
+            protocol: "https"
+        },
+        htmlNotFoundTemplate: "<html><h1>Custom 404 Template</h1></html>"
+    }
+});
+
 exports.wildcatConfigServiceWorkerEnabled = Object.assign({}, exports.wildcatConfig, {
     clientSettings: {
         serviceWorker: true


### PR DESCRIPTION
Added optional wildcatConfig parameter for passing in custom 404 error template HTML to react-wildcat-handoff that will be rendered if a route is not found.