### PR TITLE
	fix(react-wildcat-handoff): htmlNotFoundTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="7.0.1"></a>
+## [7.0.1](https://github.com/nfl/react-wildcat/compare/7.1.1...7.0.1) (2017-05-11)
+
+
+### Bug Fixes
+
+* **react-wildcat-handoff:** getHtmlNotFoundTemplate now expects a function not a string ([4ee3345](https://github.com/nfl/react-wildcat/commit/4ee3345))
+* **react-wildcat-prefetch:** Add static method to override initial data key ([#205](https://github.com/nfl/react-wildcat/issues/205)) ([6f60448](https://github.com/nfl/react-wildcat/commit/6f60448))
+
+
+
 <a name="7.2.0"></a>
 # [7.2.0](https://github.com/nfl/react-wildcat/compare/7.1.1...7.2.0) (2017-05-11)
 

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -134,7 +134,7 @@ function getHtmlNotFoundTemplate(serverSettings) {
     if (htmlNotFoundTemplate) {
         return {
             status: 404,
-            html: htmlNotFoundTemplate
+            html: htmlNotFoundTemplate()
         };
     }
     return {

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -235,7 +235,7 @@ exports.wildcatConfigWithHtmlNotFoundTemplate = Object.assign({}, exports.wildca
         appServer: {
             protocol: "https"
         },
-        htmlNotFoundTemplate: "<html><h1>Custom 404 Template</h1></html>"
+        htmlNotFoundTemplate: () => "<html><h1>Custom 404 Template</h1></html>"
     }
 });
 


### PR DESCRIPTION
htmlNotFoundTemplate property in wildcat.config.js now expects a function that returns the html template string not a string