### PR TITLE
Feature not-found component support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="7.3.0"></a>
+## [7.3.0](https://github.com/nfl/react-wildcat/compare/7.2.1...7.3.0) (2017-05-19)
+
+
+### Features
+
+* **handoff:** React components can be configured to return an http 404 status ([349ee8a](https://github.com/nfl/react-wildcat/commit/349ee8a))
+
+
+
 <a name="7.2.1"></a>
 ## [7.2.1](https://github.com/nfl/react-wildcat/compare/7.1.1...7.2.1) (2017-05-12)
 

--- a/packages/react-wildcat-handoff/package.json
+++ b/packages/react-wildcat-handoff/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-wildcat-handoff",
-  "version": "7.2.1",
+  "version": "7.3.0",
   "description": "Default client/server rendering for react-wildcat",
   "dependencies": {
     "cookie": "^0.3.1",

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -37,6 +37,8 @@ module.exports = function serverRender(cfg) {
             } else {
                 let initialData = null;
 
+                const has404Status = has404StatusRouterProperty(renderProps.components);
+
                 return Promise.all(
                     renderProps.components
                         .filter(function renderPropsFilter(component) {
@@ -92,7 +94,7 @@ module.exports = function serverRender(cfg) {
 
                         result = Object.assign({}, result, {
                             html: html,
-                            status: 200
+                            status: has404Status? 404: 200
                         });
 
                         // Delete stored object
@@ -141,4 +143,8 @@ function getHtmlNotFoundTemplate(serverSettings) {
         error: "Not found",
         status: 404
     };
+}
+
+function has404StatusRouterProperty(components) {
+    return components.some(component => component.routerProps && component.routerProps.status === 404);
 }

--- a/packages/react-wildcat-handoff/src/utils/serverRender.js
+++ b/packages/react-wildcat-handoff/src/utils/serverRender.js
@@ -37,10 +37,16 @@ module.exports = function serverRender(cfg) {
             } else {
                 let initialData = null;
 
-                const has404Status = has404StatusRouterProperty(renderProps.components);
+                let httpStatusCode = 200;
 
                 return Promise.all(
                     renderProps.components
+                        .map(function updateHttpStatusCode(component) {
+                            if (component.routerProps && component.routerProps.status !== "undefined") {
+                                httpStatusCode = component.routerProps.status;
+                            }
+                            return component;
+                        })
                         .filter(function renderPropsFilter(component) {
                             return component.prefetch;
                         })
@@ -94,7 +100,7 @@ module.exports = function serverRender(cfg) {
 
                         result = Object.assign({}, result, {
                             html: html,
-                            status: has404Status? 404: 200
+                            status: httpStatusCode
                         });
 
                         // Delete stored object
@@ -143,8 +149,4 @@ function getHtmlNotFoundTemplate(serverSettings) {
         error: "Not found",
         status: 404
     };
-}
-
-function has404StatusRouterProperty(components) {
-    return components.some(component => component.routerProps && component.routerProps.status === 404);
 }

--- a/packages/react-wildcat-handoff/test/serverHandoffSpec.js
+++ b/packages/react-wildcat-handoff/test/serverHandoffSpec.js
@@ -711,6 +711,32 @@ describe("react-wildcat-handoff/server", () => {
         });
     });
 
+    context("not-found", () => {
+        it("returns a 404 status", (done) => {
+            const serverHandoff = server(stubs.notFoundRoute);
+
+            expect(serverHandoff)
+                .to.be.a("function")
+                .that.has.property("name")
+                .that.equals("serverHandoff");
+
+            const result = serverHandoff(stubs.requests.basic, stubs.cookieParser, stubs.wildcatConfig)
+                .then(response => {
+                    expect(response)
+                        .to.be.an("object")
+                        .that.has.property("status")
+                        .that.is.a("number")
+                        .that.equals(404);
+
+                    done();
+                })
+                .catch(error => done(error));
+
+            expect(result)
+                .to.be.an.instanceof(Promise);
+        });
+    });
+
     context("service worker", () => {
         it("renders when it's enabled under https", (done) => {
             const serverHandoff = server(stubs.prefetchedRoutes);

--- a/packages/react-wildcat-handoff/test/stubFixtures.js
+++ b/packages/react-wildcat-handoff/test/stubFixtures.js
@@ -268,6 +268,9 @@ exports.Application = React.createClass({
     }
 });
 
+const NotFoundApplication = exports.Application;
+NotFoundApplication.routerProps = {status: 404};
+
 const routes = React.createElement(
     Router.Route, {
         path: "/",
@@ -294,6 +297,15 @@ exports.routes = {
     sync: {
         routes
     }
+};
+
+exports.notFoundRoute = {
+    routes: React.createElement(
+        Router.Route, {
+            path: "/",
+            component: NotFoundApplication
+        }
+    )
 };
 
 exports.callbackError = new Error("Fake Error!");


### PR DESCRIPTION
A routerProps property, containing an object with a status property with a value of 404, can be
added to a component route that can be used to return an http 404 status code.
